### PR TITLE
Add better syntactic error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 *.tsbuildinfo
 # debug files
 **/test.ts
+.idea/

--- a/packages/core/src/parser/parser.ts
+++ b/packages/core/src/parser/parser.ts
@@ -369,7 +369,8 @@ export class Parser extends CstParser {
                                 const equals = this.CONSUME(Equal);
                                 this.withError(
                                     () => this.SUBRULE2(this.operatorExpression),
-                                    `Assignment expression '${this.getText(leftSide)}${equals.image}' is missing the value you want to store`
+                                    `Assignment expression '${this.getText(leftSide)}${equals.image}' is missing the value you want to store`,
+                                    this.OR1
                                 );
                             }
                         });
@@ -392,7 +393,7 @@ export class Parser extends CstParser {
     }
 
     private withError<Type>(rule: () => Type, errorMessage: string, or?: typeof this.OR): Type {
-        return (or ?? this.OR)({
+        return (or ?? this.OR).call(this, {
             DEF: [{ ALT: rule }],
             ERR_MSG: errorMessage
         });

--- a/packages/core/src/parser/parser.ts
+++ b/packages/core/src/parser/parser.ts
@@ -208,7 +208,11 @@ export class Parser extends CstParser {
                         this.MANY_SEP({
                             SEP: Comma,
                             DEF: () =>
-                                this.withError(() => this.SUBRULE(this.listEntry), "Expected a function parameter", this.OR1)
+                                this.withError(
+                                    () => this.SUBRULE(this.listEntry),
+                                    "Expected a function parameter",
+                                    this.OR1
+                                )
                         });
                         this.CONSUME(CloseRoundBracket, { ERR_MSG: "Closing ')' of function call is missing" });
                     }


### PR DESCRIPTION
Now, quite a few errors tell the user how to fix the problem:
![grafik](https://github.com/user-attachments/assets/b0a15929-88de-4923-a376-da3cd2868ddf)
![grafik](https://github.com/user-attachments/assets/9554d183-15d8-494d-b3e9-0392b14ecb6b)
![grafik](https://github.com/user-attachments/assets/7967987b-91c2-437e-b57c-cd9867853903)
![grafik](https://github.com/user-attachments/assets/9ac0c057-3326-44a6-997f-301206d4bfad)
![grafik](https://github.com/user-attachments/assets/ecda438d-200a-4cfb-a264-a74dc0e7e5c2)
![grafik](https://github.com/user-attachments/assets/e3606c87-b296-44cd-bc7e-d5e8b3ec3130)
![grafik](https://github.com/user-attachments/assets/0a8b8fdf-e487-458d-9fc0-f3967bb38e27)
![grafik](https://github.com/user-attachments/assets/379e48d1-6713-4570-a98d-361015283a77)
