### PR TITLE
Fit diagram to viewport on initial load and with `Ctrl+Shift+F`

### DIFF
--- a/packages/diagram-common/src/model/elements/root.ts
+++ b/packages/diagram-common/src/model/elements/root.ts
@@ -19,9 +19,9 @@ export interface Root extends Element {
      */
     fonts: FontFamilyConfig[];
     /**
-     * The bounds of the whole diagram, as defined by hylimo internally, not by sprotty
+     * The bounds of the whole diagram, as defined by hylimo's internal definition, not the definition of any external tool
      */
-    hylimoBounds: Bounds;
+    rootBounds: Bounds;
 }
 
 export namespace Root {

--- a/packages/diagram-common/src/model/elements/root.ts
+++ b/packages/diagram-common/src/model/elements/root.ts
@@ -19,9 +19,9 @@ export interface Root extends Element {
      */
     fonts: FontFamilyConfig[];
     /**
-     * The bounds of the whole diagram
+     * The bounds of the whole diagram, as defined by hylimo internally, not by sprotty
      */
-    bounds: Bounds;
+    hylimoBounds: Bounds;
 }
 
 export namespace Root {

--- a/packages/diagram-render-pdf/src/pdfRenderer.ts
+++ b/packages/diagram-render-pdf/src/pdfRenderer.ts
@@ -80,14 +80,14 @@ export class PDFDiagramVisitor extends SimplifiedDiagramVisitor<PDFKit.PDFDocume
 
     override visitRoot(element: Root, context: PDFKit.PDFDocument): void {
         const [width, height] = [
-            element.bounds.size.width + 2 * this.margin,
-            element.bounds.size.height + 2 * this.margin
+            element.hylimoBounds.size.width + 2 * this.margin,
+            element.hylimoBounds.size.height + 2 * this.margin
         ];
         context.addPage({
             size: [width, height]
         });
         context.rect(0, 0, width, height).fill(this.background);
-        context.translate(-element.bounds.position.x + this.margin, -element.bounds.position.y + this.margin);
+        context.translate(-element.hylimoBounds.position.x + this.margin, -element.hylimoBounds.position.y + this.margin);
         this.visitChildren(element, context);
     }
 

--- a/packages/diagram-render-pdf/src/pdfRenderer.ts
+++ b/packages/diagram-render-pdf/src/pdfRenderer.ts
@@ -87,7 +87,10 @@ export class PDFDiagramVisitor extends SimplifiedDiagramVisitor<PDFKit.PDFDocume
             size: [width, height]
         });
         context.rect(0, 0, width, height).fill(this.background);
-        context.translate(-element.hylimoBounds.position.x + this.margin, -element.hylimoBounds.position.y + this.margin);
+        context.translate(
+            -element.hylimoBounds.position.x + this.margin,
+            -element.hylimoBounds.position.y + this.margin
+        );
         this.visitChildren(element, context);
     }
 

--- a/packages/diagram-render-pdf/src/pdfRenderer.ts
+++ b/packages/diagram-render-pdf/src/pdfRenderer.ts
@@ -80,16 +80,16 @@ export class PDFDiagramVisitor extends SimplifiedDiagramVisitor<PDFKit.PDFDocume
 
     override visitRoot(element: Root, context: PDFKit.PDFDocument): void {
         const [width, height] = [
-            element.hylimoBounds.size.width + 2 * this.margin,
-            element.hylimoBounds.size.height + 2 * this.margin
+            element.rootBounds.size.width + 2 * this.margin,
+            element.rootBounds.size.height + 2 * this.margin
         ];
         context.addPage({
             size: [width, height]
         });
         context.rect(0, 0, width, height).fill(this.background);
         context.translate(
-            -element.hylimoBounds.position.x + this.margin,
-            -element.hylimoBounds.position.y + this.margin
+            -element.rootBounds.position.x + this.margin,
+            -element.rootBounds.position.y + this.margin
         );
         this.visitChildren(element, context);
     }

--- a/packages/diagram-render-pdf/src/pdfRenderer.ts
+++ b/packages/diagram-render-pdf/src/pdfRenderer.ts
@@ -87,10 +87,7 @@ export class PDFDiagramVisitor extends SimplifiedDiagramVisitor<PDFKit.PDFDocume
             size: [width, height]
         });
         context.rect(0, 0, width, height).fill(this.background);
-        context.translate(
-            -element.rootBounds.position.x + this.margin,
-            -element.rootBounds.position.y + this.margin
-        );
+        context.translate(-element.rootBounds.position.x + this.margin, -element.rootBounds.position.y + this.margin);
         this.visitChildren(element, context);
     }
 

--- a/packages/diagram-render-svg/src/svgRenderer.ts
+++ b/packages/diagram-render-svg/src/svgRenderer.ts
@@ -100,7 +100,7 @@ class SVGDiagramVisitor extends SimplifiedDiagramVisitor<undefined, SVGNode[]> {
     }
 
     override visitRoot(element: Root): SVGNode[] {
-        const viewBox = element.bounds;
+        const viewBox = element.hylimoBounds;
         const x = viewBox.position.x - this.margin;
         const y = viewBox.position.y - this.margin;
         const width = viewBox.size.width + this.margin * 2;

--- a/packages/diagram-render-svg/src/svgRenderer.ts
+++ b/packages/diagram-render-svg/src/svgRenderer.ts
@@ -100,7 +100,7 @@ class SVGDiagramVisitor extends SimplifiedDiagramVisitor<undefined, SVGNode[]> {
     }
 
     override visitRoot(element: Root): SVGNode[] {
-        const viewBox = element.hylimoBounds;
+        const viewBox = element.rootBounds;
         const x = viewBox.position.x - this.margin;
         const y = viewBox.position.y - this.margin;
         const width = viewBox.size.width + this.margin * 2;

--- a/packages/diagram-ui/src/features/viewport/di.config.ts
+++ b/packages/diagram-ui/src/features/viewport/di.config.ts
@@ -1,11 +1,14 @@
 import { ContainerModule } from "inversify";
-import { TYPES } from "sprotty";
+import { configureActionHandler, TYPES } from "sprotty";
 import { ViewportTouchListener } from "./touch.js";
+import { SetModelAction } from "sprotty-protocol";
+import { SetModelActionHandler } from "./setModelActionHandler.js";
 
 /**
  * Module which configures the ViewportTouchListener
  */
-export const viewportModule = new ContainerModule((bind) => {
+export const viewportModule = new ContainerModule((bind, _, isBound) => {
     bind(ViewportTouchListener).toSelf().inSingletonScope();
     bind(TYPES.IVNodePostprocessor).toService(ViewportTouchListener);
+    configureActionHandler({ bind, isBound }, SetModelAction.KIND, SetModelActionHandler);
 });

--- a/packages/diagram-ui/src/features/viewport/setModelActionHandler.ts
+++ b/packages/diagram-ui/src/features/viewport/setModelActionHandler.ts
@@ -1,0 +1,13 @@
+import { injectable } from "inversify";
+import { IActionHandler, ICommand } from "sprotty";
+import { Action, FitToScreenAction } from "sprotty-protocol";
+
+/**
+ * Action handler that executes fit-to-screen whenever the model has been set (i.e. copy-paste, initial load, …)
+ */
+@injectable()
+export class SetModelActionHandler implements IActionHandler {
+    handle(_: Action): ICommand | Action | void {
+        return FitToScreenAction.create([]);
+    }
+}

--- a/packages/diagram-ui/src/features/viewport/setModelActionHandler.ts
+++ b/packages/diagram-ui/src/features/viewport/setModelActionHandler.ts
@@ -3,7 +3,7 @@ import { IActionHandler, ICommand } from "sprotty";
 import { Action, FitToScreenAction } from "sprotty-protocol";
 
 /**
- * Action handler that executes fit-to-screen whenever the model has been set (i.e. copy-paste, initial load, …)
+ * Action handler that executes fit-to-screen whenever the model has been set (initial page load)
  */
 @injectable()
 export class SetModelActionHandler implements IActionHandler {

--- a/packages/diagram-ui/src/model/sRoot.ts
+++ b/packages/diagram-ui/src/model/sRoot.ts
@@ -23,7 +23,7 @@ export class SRoot extends ViewportRootElementImpl {
     /**
      * The bounds of the whole diagram, as defined by hylimo internally, not by sprotty
      */
-    hylimoBounds!: HylimoBounds;
+    rootBounds!: HylimoBounds;
 
     /**
      * The revision number increasing with each change.
@@ -61,10 +61,10 @@ export class SRoot extends ViewportRootElementImpl {
 
     override get bounds(): Bounds {
         return {
-            x: this.hylimoBounds.position.x,
-            y: this.hylimoBounds.position.y,
-            width: this.hylimoBounds.size.width,
-            height: this.hylimoBounds.size.height
+            x: this.rootBounds.position.x,
+            y: this.rootBounds.position.y,
+            width: this.rootBounds.size.width,
+            height: this.rootBounds.size.height
         };
     }
 

--- a/packages/diagram-ui/src/model/sRoot.ts
+++ b/packages/diagram-ui/src/model/sRoot.ts
@@ -3,6 +3,8 @@ import { ModelIndexImpl, ViewportRootElementImpl } from "sprotty";
 import { SCanvasAxisAlignedSegment } from "./canvas/sCanvasAxisAlignedSegment.js";
 import { SCanvasLayoutEngine } from "./canvas/sCanvasLayoutEngine.js";
 import { Matrix, compose, translate, scale } from "transformation-matrix";
+import { Bounds } from "sprotty-protocol";
+import { Bounds as HylimoBounds } from "@hylimo/diagram-common";
 
 /**
  * Root element.
@@ -17,6 +19,11 @@ export class SRoot extends ViewportRootElementImpl {
      * Defined font families
      */
     fonts!: FontFamilyConfig[];
+
+    /**
+     * The bounds of the whole diagram, as defined by hylimo internally, not by sprotty
+     */
+    hylimoBounds!: HylimoBounds;
 
     /**
      * The revision number increasing with each change.
@@ -50,6 +57,15 @@ export class SRoot extends ViewportRootElementImpl {
             this.layoutEngineVersion = this.changeRevision;
         }
         return this.currentLayoutEngine;
+    }
+
+    override get bounds(): Bounds {
+        return {
+            x: this.hylimoBounds.position.x,
+            y: this.hylimoBounds.position.y,
+            width: this.hylimoBounds.size.width,
+            height: this.hylimoBounds.size.height
+        };
     }
 
     /**

--- a/packages/diagram/src/layout/engine/layoutEngine.ts
+++ b/packages/diagram/src/layout/engine/layoutEngine.ts
@@ -165,7 +165,7 @@ export class LayoutEngine {
                 children: elements,
                 fonts: fontFamilyConfigs,
                 edits: {},
-                bounds
+                hylimoBounds: bounds
             },
             elementLookup: layout.elementLookup,
             layoutElementLookup: layout.layoutElementLookup

--- a/packages/diagram/src/layout/engine/layoutEngine.ts
+++ b/packages/diagram/src/layout/engine/layoutEngine.ts
@@ -165,7 +165,7 @@ export class LayoutEngine {
                 children: elements,
                 fonts: fontFamilyConfigs,
                 edits: {},
-                hylimoBounds: bounds
+                rootBounds: bounds
             },
             elementLookup: layout.elementLookup,
             layoutElementLookup: layout.layoutElementLookup


### PR DESCRIPTION
Now, your diagram will be autofitted to the viewport when loading the page,
and when you manually press <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd>.
These features were already possible in Sprotty, but disabled as no bounds were provided.

Since #31, the bounds have been calculated in Hylimos definition, so the main task was to map them from Hylimo's to Sprotty's definition.

As a side effect, <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd> is now possible as well which does effectively the same but without displaying the whole diagram but only parts of it/the diagram with extra margin for small diagrams.

In follow up PRs, we can still think about triggering the fitting automatically when _enough_ changes happen simultaneously, i.e. you replace the diagram with another or add 10 classes at once

Fixes #11 