### PR TITLE
improve undo redo experience

### DIFF
--- a/packages/diagram-protocol/src/diagram/transaction/transactionalAction.ts
+++ b/packages/diagram-protocol/src/diagram/transaction/transactionalAction.ts
@@ -20,7 +20,7 @@ export interface TransactionalAction {
      * If true, the action commits the transaction
      * and no further actions with the same transactionId are possible.
      */
-    commited: boolean;
+    committed: boolean;
     /**
      * The edits to perform
      */

--- a/packages/diagram-protocol/src/diagram/undo-redo/remoteRedoAction.ts
+++ b/packages/diagram-protocol/src/diagram/undo-redo/remoteRedoAction.ts
@@ -1,0 +1,22 @@
+/**
+ * Action to redo an action on a remote client
+ */
+export interface RemoteRedoAction {
+    kind: typeof RemoteRedoAction.KIND;
+}
+
+export namespace RemoteRedoAction {
+    /**
+     * Kind of RemoteRedoAction
+     */
+    export const KIND = "remoteRedoAction";
+    /**
+     * Evaluates if the provided action is a RemoteRedoAction
+     *
+     * @param action the Action to check
+     * @returns true if the action is a RemoteRedoAction
+     */
+    export function isRemoteRedoAction(action: any): action is RemoteRedoAction {
+        return action.kind === KIND;
+    }
+}

--- a/packages/diagram-protocol/src/diagram/undo-redo/remoteUndoAction.ts
+++ b/packages/diagram-protocol/src/diagram/undo-redo/remoteUndoAction.ts
@@ -1,0 +1,22 @@
+/**
+ * Action to undo an action on a remote client
+ */
+export interface RemoteUndoAction {
+    kind: typeof RemoteUndoAction.KIND;
+}
+
+export namespace RemoteUndoAction {
+    /**
+     * Kind of RemoteUndoAction
+     */
+    export const KIND = "RemoteUndoAction";
+    /**
+     * Evaluates if the provided action is a RemoteUndoAction
+     *
+     * @param action the Action to check
+     * @returns true if the action is a RemoteUndoAction
+     */
+    export function isRemoteUndoAction(action: any): action is RemoteUndoAction {
+        return action.kind === KIND;
+    }
+}

--- a/packages/diagram-protocol/src/index.ts
+++ b/packages/diagram-protocol/src/index.ts
@@ -3,6 +3,8 @@ export * from "./diagram/transaction/defaultEditTypes.js";
 export * from "./diagram/transaction/edit.js";
 export * from "./diagram/transaction/incrementalUpdateAction.js";
 export * from "./diagram/transaction/transactionalAction.js";
+export * from "./diagram/undo-redo/remoteRedoAction.js";
+export * from "./diagram/undo-redo/remoteUndoAction.js";
 export * from "./lsp/config.js";
 export * from "./lsp/diagramNotificationTypes.js";
 export * from "./lsp/diagramRequestTypes.js";

--- a/packages/diagram-ui/src/base/diagramServerProxy.ts
+++ b/packages/diagram-ui/src/base/diagramServerProxy.ts
@@ -1,16 +1,71 @@
-import { NavigateToSourceAction, TransactionalAction } from "@hylimo/diagram-protocol";
+import {
+    NavigateToSourceAction,
+    TransactionalAction,
+    RemoteUndoAction,
+    RemoteRedoAction
+} from "@hylimo/diagram-protocol";
 import { injectable } from "inversify";
 import { ActionHandlerRegistry, DiagramServerProxy as SprottyDiagramServerProxy } from "sprotty";
+import { Action } from "sprotty-protocol";
 
 /**
  * DiagramServerProxy which handles additional commands
  */
 @injectable()
 export abstract class DiagramServerProxy extends SprottyDiagramServerProxy {
+    /**
+     * Whether the server is currently in a transaction
+     */
+    private inTransaction = false;
+
     override initialize(registry: ActionHandlerRegistry): void {
         super.initialize(registry);
 
         registry.register(TransactionalAction.KIND, this);
         registry.register(NavigateToSourceAction.KIND, this);
+        registry.register(RemoteUndoAction.KIND, this);
+        registry.register(RemoteRedoAction.KIND, this);
     }
+
+    protected override handleLocally(action: Action): boolean {
+        if (RemoteUndoAction.isRemoteUndoAction(action)) {
+            this.handleUndo();
+            return false;
+        }
+        if (RemoteRedoAction.isRemoteRedoAction(action)) {
+            this.handleRedo();
+            return false;
+        }
+        if (TransactionalAction.isTransactionalAction(action)) {
+            if (action.committed) {
+                this.handleTransactionCommit();
+                this.inTransaction = false;
+            } else if (!this.inTransaction) {
+                this.handleTransactionStart();
+                this.inTransaction = true;
+            }
+            return true;
+        }
+        return super.handleLocally(action);
+    }
+
+    /**
+     * Handles an undo action
+     */
+    protected abstract handleUndo(): void;
+
+    /**
+     * Handles a redo action
+     */
+    protected abstract handleRedo(): void;
+
+    /**
+     * Handles the start of a transaction
+     */
+    protected abstract handleTransactionStart(): void;
+
+    /**
+     * Handles the end of a transaction
+     */
+    protected abstract handleTransactionCommit(): void;
 }

--- a/packages/diagram-ui/src/di.config.ts
+++ b/packages/diagram-ui/src/di.config.ts
@@ -28,7 +28,7 @@ import {
     TYPES,
     decorationModule,
     registerModelElement,
-    undoRedoModule
+    undoRedoModule as sprottyUndoRedoModule
 } from "sprotty";
 import { CommandStack } from "./base/commandStack.js";
 import { moveModule } from "./features/move/di.config.js";
@@ -66,6 +66,7 @@ import { navigationModule } from "./features/navigation/di.config.js";
 import { splitCanvasSegmentModule } from "./features/split-canvas-segment/di.config.js";
 import { resetCanvasBoundsModule } from "./features/canvas-bounds/di.config.js";
 import { viewportModule } from "./features/viewport/di.config.js";
+import { undoRedoModule } from "./features/undo-redo/di.config.js";
 
 /**
  * The module used
@@ -111,7 +112,7 @@ const diagramModule = new ContainerModule((bind, unbind, isBound, rebind) => {
 export function createContainer(widgetId: string): Container {
     const container = new Container();
     loadDefaultModules(container, {
-        exclude: [sprottyUpdateModule, sprottyMoveModule, sprottyZOrderModule, decorationModule, undoRedoModule]
+        exclude: [sprottyUpdateModule, sprottyMoveModule, sprottyZOrderModule, decorationModule, sprottyUndoRedoModule]
     });
     container.load(
         updateModule,
@@ -121,7 +122,8 @@ export function createContainer(widgetId: string): Container {
         resetCanvasBoundsModule,
         navigationModule,
         splitCanvasSegmentModule,
-        viewportModule
+        viewportModule,
+        undoRedoModule
     );
     container.load(diagramModule);
 

--- a/packages/diagram-ui/src/features/move/moveHandler.ts
+++ b/packages/diagram-ui/src/features/move/moveHandler.ts
@@ -17,7 +17,7 @@ export abstract class MoveHandler {
      * @param dx the absolute x offset
      * @param dy the absolute y offset
      * @param sequenceNumber the sequence number of the action
-     * @param commited if true, this is the final action of the transaction
+     * @param committed if true, this is the final action of the transaction
      * @param event the mouse event which triggered the move
      * @returns the generated action
      */
@@ -25,14 +25,14 @@ export abstract class MoveHandler {
         dx: number,
         dy: number,
         sequenceNumber: number,
-        commited: boolean,
+        committed: boolean,
         event: MouseEvent
     ): TransactionalAction {
         return {
             kind: TransactionalAction.KIND,
             transactionId: this.transactionId,
             sequenceNumber,
-            commited,
+            committed,
             edits: this.generateEdits(dx, dy, event)
         };
     }

--- a/packages/diagram-ui/src/features/split-canvas-segment/splitCanvasSegmentMouseListener.ts
+++ b/packages/diagram-ui/src/features/split-canvas-segment/splitCanvasSegmentMouseListener.ts
@@ -58,7 +58,7 @@ export class SplitCanvasSegmentMouseListener extends MouseListener {
                 kind: TransactionalAction.KIND,
                 transactionId: this.transactionIdProvider.generateId(),
                 sequenceNumber: 0,
-                commited: true,
+                committed: true,
                 edits
             };
             return [action];

--- a/packages/diagram-ui/src/features/undo-redo/di.config.ts
+++ b/packages/diagram-ui/src/features/undo-redo/di.config.ts
@@ -1,0 +1,11 @@
+import { ContainerModule } from "inversify";
+import { RemoteUndoRedoKeyListener } from "./remoteUndoRedoKeyListener.js";
+import { TYPES } from "sprotty";
+
+/**
+ * Module for remote undo and redo actions
+ */
+export const undoRedoModule = new ContainerModule((bind) => {
+    bind(RemoteUndoRedoKeyListener).toSelf().inSingletonScope();
+    bind(TYPES.KeyListener).toService(RemoteUndoRedoKeyListener);
+});

--- a/packages/diagram-ui/src/features/undo-redo/remoteUndoRedoKeyListener.ts
+++ b/packages/diagram-ui/src/features/undo-redo/remoteUndoRedoKeyListener.ts
@@ -7,13 +7,14 @@ import { Action } from "sprotty-protocol";
  */
 export class RemoteUndoRedoKeyListener extends KeyListener {
     override keyDown(element: SModelElementImpl, event: KeyboardEvent): Action[] {
-        if (isCtrlOrCmd(event)) {
-            if (event.key.toLowerCase() == "y" || (event.shiftKey && event.key.toLowerCase() == "z")) {
-                return [{ kind: RemoteRedoAction.KIND } satisfies RemoteRedoAction];
-            }
-            if (event.key.toLowerCase() == "z") {
-                return [{ kind: RemoteUndoAction.KIND } satisfies RemoteUndoAction];
-            }
+        if (!isCtrlOrCmd(event)) {
+            return [];
+        }
+        if (event.key.toLowerCase() == "y" || (event.shiftKey && event.key.toLowerCase() == "z")) {
+            return [{ kind: RemoteRedoAction.KIND } satisfies RemoteRedoAction];
+        }
+        if (event.key.toLowerCase() == "z") {
+            return [{ kind: RemoteUndoAction.KIND } satisfies RemoteUndoAction];
         }
         return [];
     }

--- a/packages/diagram-ui/src/features/undo-redo/remoteUndoRedoKeyListener.ts
+++ b/packages/diagram-ui/src/features/undo-redo/remoteUndoRedoKeyListener.ts
@@ -1,5 +1,5 @@
 import { RemoteRedoAction, RemoteUndoAction } from "@hylimo/diagram-protocol";
-import { isCtrlOrCmd, isMac, KeyListener, SModelElementImpl } from "sprotty";
+import { isCtrlOrCmd, KeyListener, SModelElementImpl } from "sprotty";
 import { Action } from "sprotty-protocol";
 
 /**
@@ -8,7 +8,7 @@ import { Action } from "sprotty-protocol";
 export class RemoteUndoRedoKeyListener extends KeyListener {
     override keyDown(element: SModelElementImpl, event: KeyboardEvent): Action[] {
         if (isCtrlOrCmd(event)) {
-            if ((!isMac() && event.key.toLowerCase() == "y") || (event.shiftKey && event.key.toLowerCase() == "z")) {
+            if (event.key.toLowerCase() == "y" || (event.shiftKey && event.key.toLowerCase() == "z")) {
                 return [{ kind: RemoteRedoAction.KIND } satisfies RemoteRedoAction];
             }
             if (event.key.toLowerCase() == "z") {

--- a/packages/diagram-ui/src/features/undo-redo/remoteUndoRedoKeyListener.ts
+++ b/packages/diagram-ui/src/features/undo-redo/remoteUndoRedoKeyListener.ts
@@ -1,0 +1,20 @@
+import { RemoteRedoAction, RemoteUndoAction } from "@hylimo/diagram-protocol";
+import { isCtrlOrCmd, isMac, KeyListener, SModelElementImpl } from "sprotty";
+import { Action } from "sprotty-protocol";
+
+/**
+ * Key listener for remote undo and redo actions
+ */
+export class RemoteUndoRedoKeyListener extends KeyListener {
+    override keyDown(element: SModelElementImpl, event: KeyboardEvent): Action[] {
+        if (isCtrlOrCmd(event)) {
+            if ((!isMac() && event.key.toLowerCase() == "y") || (event.shiftKey && event.key.toLowerCase() == "z")) {
+                return [{ kind: RemoteRedoAction.KIND } satisfies RemoteRedoAction];
+            }
+            if (event.key.toLowerCase() == "z") {
+                return [{ kind: RemoteUndoAction.KIND } satisfies RemoteUndoAction];
+            }
+        }
+        return [];
+    }
+}

--- a/packages/diagram-ui/src/index.ts
+++ b/packages/diagram-ui/src/index.ts
@@ -24,6 +24,8 @@ export * from "./features/split-canvas-segment/di.config.js";
 export * from "./features/split-canvas-segment/splitCanvasSegmentMouseListener.js";
 export * from "./features/transaction/di.config.js";
 export * from "./features/transaction/transactionIdProvider.js";
+export * from "./features/undo-redo/di.config.js";
+export * from "./features/undo-redo/remoteUndoRedoKeyListener.js";
 export * from "./features/update/di.config.js";
 export * from "./features/update/incrementalUpdateModel.js";
 export * from "./features/update/updateModel.js";

--- a/packages/language-server/src/edit/transactionManager.ts
+++ b/packages/language-server/src/edit/transactionManager.ts
@@ -96,7 +96,7 @@ export class TransactionManager {
             this.diagram.applyEdit(textDocumentEdit);
             this.lastAppliedAction = this.lastKnownAction;
         }
-        if (this.lastAppliedAction?.commited) {
+        if (this.lastAppliedAction?.committed) {
             this.resetActionState();
         }
     }

--- a/website/.vitepress/components/HylimoEditor.vue
+++ b/website/.vitepress/components/HylimoEditor.vue
@@ -184,20 +184,20 @@ onMounted(async () => {
             currentLanguageClient.sendNotification(DiagramActionNotification.type, message);
         }
 
-        protected handleUndo(): void {
+        protected override handleUndo(): void {
             editor.trigger("diagram", "undo", {});
         }
 
-        protected handleRedo(): void {
+        protected override handleRedo(): void {
             editor.trigger("diagram", "redo", {});
         }
 
-        protected handleTransactionStart(): void {
+        protected override handleTransactionStart(): void {
             editorModel.pushStackElement();
             transactionState.value = TransactionState.InProgress;
         }
 
-        protected handleTransactionCommit(): void {
+        protected override handleTransactionCommit(): void {
             transactionState.value = TransactionState.Committed;
         }
     }

--- a/website/.vitepress/components/HylimoEditor.vue
+++ b/website/.vitepress/components/HylimoEditor.vue
@@ -36,6 +36,7 @@ import { language, languageClientKey } from "../theme/lspPlugin";
 import { Disposable } from "vscode-languageserver-protocol";
 import { useResizeObserver } from "@vueuse/core";
 import { v4 as uuid } from "uuid";
+import * as monaco from "monaco-editor";
 
 const id = uuid();
 
@@ -96,7 +97,7 @@ onMounted(async () => {
                 $type: "classic",
                 editorOptions: {
                     language,
-                    value: model.value,
+                    model: null,
                     automaticLayout: true,
                     fixedOverflowWidgets: true,
                     hover: {
@@ -118,13 +119,14 @@ onMounted(async () => {
     const editor = wrapper.getEditor()!;
     hideMainContent.value = false;
 
-    const editorModel = editor.getModel()!;
-    const pushStackElement = editorModel.pushStackElement;
+    const editorModel = monaco.editor.createModel(model.value, language);
+    editor.setModel(editorModel);
+    const pushStackElement = editorModel.pushStackElement.bind(editorModel);
 
     // override pushStackElement to ignore undo stops during transactions
     editorModel.pushStackElement = () => {
         if (transactionState.value == TransactionState.None) {
-            pushStackElement.call(editorModel);
+            pushStackElement();
         }
     };
 


### PR DESCRIPTION
## new features
- undo redo works in graphical editor
- for each graphical interaction, only one undo stop is created. As described in the issue, doing this requires some hacky workarounds due to missing features in LSP / Monaco / VSCode. Due to user feedback, I believe this workaround is worth it

## issues
- closes #44 

## future work
In case there will ever be an addition to LSP, we could remove the workaround. Due to multiple closed issues across LSP, Monaco, and VSCode, I doubt this will happen anytime soon.