### PR TITLE
Fix box layout offset

### DIFF
--- a/packages/diagram/src/layout/elements/hboxLayoutConfig.ts
+++ b/packages/diagram/src/layout/elements/hboxLayoutConfig.ts
@@ -71,8 +71,8 @@ export class HBoxLayoutConfig extends BoxLayoutConfig {
         const parts: BoxOutlinePart[] = contents.map((content) => {
             const bounds = content.layoutBounds!;
             return {
-                primaryOffset: bounds.position.x - position.x,
-                secondaryOffset: bounds.position.y - position.y,
+                primaryOffset: bounds.position.x,
+                secondaryOffset: bounds.position.y,
                 primaryLength: bounds.size.width,
                 secondaryLength: bounds.size.height
             };

--- a/packages/diagram/src/layout/elements/vboxLayoutConfig.ts
+++ b/packages/diagram/src/layout/elements/vboxLayoutConfig.ts
@@ -71,8 +71,8 @@ export class VBoxLayoutConfig extends BoxLayoutConfig {
         const parts: BoxOutlinePart[] = contents.map((content) => {
             const bounds = content.layoutBounds!;
             return {
-                primaryOffset: bounds.position.y - position.y,
-                secondaryOffset: bounds.position.x - position.x,
+                primaryOffset: bounds.position.y,
+                secondaryOffset: bounds.position.x,
                 primaryLength: bounds.size.height,
                 secondaryLength: bounds.size.width
             };

--- a/packages/diagram/src/layout/engine/layout.ts
+++ b/packages/diagram/src/layout/engine/layout.ts
@@ -287,22 +287,22 @@ export class Layout {
         if (styles.vAlign == undefined) {
             minHeight = constraints.min.height - marginY;
         }
+        const maxWidth = Math.max(
+            styles.width ?? Math.min(styles.maxWidth ?? Number.POSITIVE_INFINITY, constraints.max.width - marginX),
+            0
+        );
+        const maxHeight = Math.max(
+            styles.height ?? Math.min(styles.maxHeight ?? Number.POSITIVE_INFINITY, constraints.max.height - marginY),
+            0
+        );
         return {
             min: {
-                width: Math.max(styles.width ?? Math.max(styles.minWidth ?? 0, minWidth), 0),
-                height: Math.max(styles.height ?? Math.max(styles.minHeight ?? 0, minHeight), 0)
+                width: Math.max(styles.width ?? Math.min(Math.max(styles.minWidth ?? 0, minWidth), maxWidth), 0),
+                height: Math.max(styles.height ?? Math.min(Math.max(styles.minHeight ?? 0, minHeight), maxHeight), 0)
             },
             max: {
-                width: Math.max(
-                    styles.width ??
-                        Math.min(styles.maxWidth ?? Number.POSITIVE_INFINITY, constraints.max.width - marginX),
-                    0
-                ),
-                height: Math.max(
-                    styles.height ??
-                        Math.min(styles.maxHeight ?? Number.POSITIVE_INFINITY, constraints.max.height - marginY),
-                    0
-                )
+                width: maxWidth,
+                height: maxHeight
             }
         };
     }

--- a/website/docs/docs.md
+++ b/website/docs/docs.md
@@ -282,6 +282,11 @@ classDiagram {
 
     hdist = 300
 
+    top = 0.1608
+    left = [4, 0.5]
+    right = [2, 0.5]
+    bottom = [3, 0.5]
+
     chevrotain = customPackage("Chevrotaion") styles {
         class += "foreign"
     }
@@ -345,72 +350,69 @@ classDiagram {
     }
 
     diagram --> core with {
-        over = start(Position.Top).line(end(Position.Bottom))
+        over = start(top).line(end(bottom))
     }
 
     diagram --> diagramCommon with {
-        over = start(Position.Right).line(end(Position.Left))
+        over = start(right).line(end(left))
     }
 
     diagram --> _fonts with {
-        over = start(Position.Top + 0.05).axisAligned(
-            -0.51,
-            end(Position.Bottom)
-        )
+        over = start(0.2).axisAligned(-0.51, end(bottom))
     }
 
     renderSvg --> diagramCommon with {
-        over = start(Position.Right).axisAligned(
+        over = start(right).axisAligned(
             -1,
             rpos(diagramUI, 137, 0),
             0,
-            end(Position.Right)
+            end(right)
         )
     }
 
     renderPdf --> renderSvg with {
-        over = start(Position.Right).line(end(Position.Left))
+        over = start(right).line(end(left))
     }
 
     renderPdf --> diagram with {
-        over = start(Position.Left).axisAligned(
+        over = start(left).axisAligned(
             1,
             rpos(languageServer, -149, 2),
             0,
-            end(Position.Left)
+            end(left)
         )
     }
 
     languageServer --> diagram with {
-        over = start(Position.Top).line(end(Position.Bottom))
+        over = start(top).line(end(bottom))
     }
 
     languageServer --> diagramProtocol with {
-        over = start(Position.Right).line(end(Position.Left))
+        over = start(right).line(end(left))
     }
 
     diagramUI --> diagramProtocol with {
-        over = start(Position.Left).line(end(Position.Right))
+        over = start(left).line(end(right))
     }
 
-    diagramUI -- rpos(lpos(diagramCommon, 0), hdist - 100, 0) with {
-        over = start(Position.Top).line(end())
+    diagramUI --> diagramCommon with {
+        over = start(top).axisAligned(0, end(right))
     }
 
     languageServer --> vscodeLSP with {
-        over = start(Position.Left).line(end(Position.Right))
+        over = start(left).line(end(right))
     }
 
     core --> chevrotain with {
-        over = start(Position.Left).line(end(Position.Right))
+        over = start(left).line(end(right))
     }
 
     renderPdf --> pdfkit with {
-        over = start(Position.Bottom).line(end(Position.Top))
+        over = start(bottom).line(end(top))
     }
 
     diagramUI --> sprotty with {
-        over = start(Position.Right).line(end(Position.Left))
+        over = start(right).line(end(left))
     }
 
     globe = {


### PR DESCRIPTION
## bugfixes
- fix vbox/hbox outline when canvas element does not have top-left alignment
  - well I thought the bounds do not consider the position, which was wrong...
- fix example diagram
- fix bug where conflicting max/min constraints results in weird layout
  - conflicting meaning min > max
  - as by the docs (thesis), max should in this case win

## issues
- fixes #52 