### PR TITLE
fix 2 connection divide by zero errors

### DIFF
--- a/packages/diagram-common/src/common/point.ts
+++ b/packages/diagram-common/src/common/point.ts
@@ -14,7 +14,7 @@ export namespace Point {
 
     /**
      * Checks if two points are equal
-     * 
+     *
      * @param a the first point
      * @param b the second point
      * @returns true if the points are equal

--- a/packages/diagram-common/src/common/point.ts
+++ b/packages/diagram-common/src/common/point.ts
@@ -11,4 +11,15 @@ export namespace Point {
      * Constant origin at (0,0)
      */
     export const ORIGIN = Object.freeze({ x: 0, y: 0 });
+
+    /**
+     * Checks if two points are equal
+     * 
+     * @param a the first point
+     * @param b the second point
+     * @returns true if the points are equal
+     */
+    export function equals(a: Point, b: Point): boolean {
+        return a.x === b.x && a.y === b.y;
+    }
 }

--- a/packages/diagram-common/src/model/elements/canvas/canvasAxisAlignedSegment.ts
+++ b/packages/diagram-common/src/model/elements/canvas/canvasAxisAlignedSegment.ts
@@ -59,10 +59,15 @@ export namespace CanvasAxisAlignedSegment {
         pos: number,
         marker: Marker
     ): MarkerLayoutInformation {
+        let helperPos: Point;
         if (pos > -1 && pos <= 0) {
-            return calculateMarkerRenderInformationInternal(point, { x: point.x, y: endPoint.y }, marker);
+            helperPos = { x: point.x, y: endPoint.y };
         } else {
-            return calculateMarkerRenderInformationInternal(point, { x: endPoint.x, y: point.y }, marker);
+            helperPos = { x: endPoint.x, y: point.y };
         }
+        if (Point.equals(helperPos, point)) {
+            helperPos = endPoint;
+        }
+        return calculateMarkerRenderInformationInternal(point, helperPos, marker);
     }
 }

--- a/packages/diagram-common/src/model/elements/canvas/canvasConnectionSegment.ts
+++ b/packages/diagram-common/src/model/elements/canvas/canvasConnectionSegment.ts
@@ -26,6 +26,14 @@ export function calculateMarkerRenderInformationInternal(
     helperPos: Point,
     marker: Marker
 ): MarkerLayoutInformation {
+    if (Point.equals(pos, helperPos)) {
+        return {
+            rotation: 0,
+            newPosition: pos,
+            marker,
+            position: pos
+        };
+    }
     const markerWidth = marker.width * marker.lineStart;
     const rotation = (Math.atan2(pos.y - helperPos.y, pos.x - helperPos.x) * 180) / Math.PI;
     const normalizedDelta = Math2D.normalize(Math2D.sub(helperPos, pos));


### PR DESCRIPTION
## bugfixes
- fixes marker (and path) layouting, if
  - a axis-aligned segment is a vertical/horizontal line
  - any type of segment starts where it ends
    - in this case a rotation for the marker cannot be calculated, thus defaults to 0
    - also this is a dumb corner case which should never happen in practice for any valid diagram

## issues
- closes #58 