### PR TITLE
Add autocompletion for named function arguments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10501,6 +10501,7 @@
             }
         },
         "packages/cli": {
+            "name": "@hylimo/cli",
             "version": "1.1.2",
             "license": "MIT",
             "dependencies": {
@@ -10514,6 +10515,7 @@
             }
         },
         "packages/core": {
+            "name": "@hylimo/core",
             "version": "1.1.2",
             "license": "MIT",
             "dependencies": {
@@ -10521,6 +10523,7 @@
             }
         },
         "packages/diagram": {
+            "name": "@hylimo/diagram",
             "version": "1.1.2",
             "license": "MIT",
             "dependencies": {
@@ -10537,6 +10540,7 @@
             }
         },
         "packages/diagram-common": {
+            "name": "@hylimo/diagram-common",
             "version": "1.1.2",
             "license": "MIT",
             "dependencies": {
@@ -10549,6 +10553,7 @@
             }
         },
         "packages/diagram-protocol": {
+            "name": "@hylimo/diagram-protocol",
             "version": "1.1.2",
             "license": "MIT",
             "dependencies": {
@@ -10558,6 +10563,7 @@
             }
         },
         "packages/diagram-render-pdf": {
+            "name": "@hylimo/diagram-render-pdf",
             "version": "1.1.2",
             "license": "MIT",
             "dependencies": {
@@ -10570,6 +10576,7 @@
             }
         },
         "packages/diagram-render-svg": {
+            "name": "@hylimo/diagram-render-svg",
             "version": "1.1.2",
             "license": "MIT",
             "dependencies": {
@@ -10578,6 +10585,7 @@
             }
         },
         "packages/diagram-ui": {
+            "name": "@hylimo/diagram-ui",
             "version": "1.1.2",
             "license": "EPL-2.0",
             "dependencies": {
@@ -10589,10 +10597,12 @@
             }
         },
         "packages/fonts": {
+            "name": "@hylimo/fonts",
             "version": "1.1.2",
             "license": "MIT"
         },
         "packages/language-server": {
+            "name": "@hylimo/language-server",
             "version": "1.1.2",
             "license": "MIT",
             "dependencies": {

--- a/packages/core/src/runtime/runtimeAstTransformer.ts
+++ b/packages/core/src/runtime/runtimeAstTransformer.ts
@@ -179,7 +179,7 @@ export class RuntimeAstTransformer extends ASTVisitor<undefined, ExecutableExpre
      * @param args the list entries to map
      * @returns the mapped list entries
      */
-    private generateListEntries(args: ListEntry[]): ExecutableListEntry[] {
+    protected generateListEntries(args: ListEntry[]): ExecutableListEntry[] {
         return args.map((arg) => {
             return {
                 name: arg.name,
@@ -194,7 +194,7 @@ export class RuntimeAstTransformer extends ASTVisitor<undefined, ExecutableExpre
      * @param expression the expression to return if keepExpression is true
      * @returns the provided expression if keepExpression is true, otherwise undefined
      */
-    private optionalExpression<T extends Expression>(expression: T): T | undefined {
+    protected optionalExpression<T extends Expression>(expression: T): T | undefined {
         return this.keepExpression ? expression : undefined;
     }
 }

--- a/packages/language-server/src/completion/completableFieldSelfInvocationExpression.ts
+++ b/packages/language-server/src/completion/completableFieldSelfInvocationExpression.ts
@@ -1,0 +1,37 @@
+import { FieldSelfInvocationExpression } from "@hylimo/core/lib/ast/fieldSelfInvocationExpression.js";
+import { InterpreterContext } from "@hylimo/core/lib/runtime/interpreter/interpreterContext.js";
+import { LabeledValue } from "@hylimo/core/lib/runtime/objects/labeledValue.js";
+import { ExecutableAbstractInvocationExpression } from "@hylimo/core/lib/runtime/ast/executableAbstractInvocationExpression.js";
+import { ExecutableListEntry } from "@hylimo/core/lib/runtime/ast/executableListEntry.js";
+import { ExecutableExpression } from "@hylimo/core/lib/runtime/ast/executableExpression.js";
+import { supplyNamedArguments } from "./completionGenerator.js";
+
+/**
+ * Provides enhanced autocompletion for `this["hello"](…)`, i.e. by autocompleting `…` with documented named arguments of the hello function
+ */
+export class CompletableFieldSelfInvocationExpression extends ExecutableAbstractInvocationExpression<FieldSelfInvocationExpression> {
+    /**
+     * Creates a new CompletableFieldSelfInvocationExpression consisting of an expression of which the result should be invoked,
+     * and a set of optionally named expressions as arguments
+     *
+     * @param expression the expression this represents
+     * @param argumentExpressions evaluated to provide arguments
+     * @param target evaluated to provide the function to invoke
+     * @param name the name of the field to access
+     */
+    constructor(
+        expression: FieldSelfInvocationExpression | undefined,
+        argumentExpressions: ExecutableListEntry[],
+        readonly target: ExecutableExpression<any>,
+        readonly name: string | number
+    ) {
+        super(expression, argumentExpressions);
+    }
+
+    override evaluateInternal(context: InterpreterContext): LabeledValue {
+        const targetValue = this.target.evaluateWithSource(context);
+        const fieldValue = targetValue.value.getFieldValue(this.name, context);
+
+        return supplyNamedArguments(fieldValue, targetValue, context, this.argumentExpressions, this.expression!);
+    }
+}

--- a/packages/language-server/src/completion/completableIndexSelfInvocationExpression.ts
+++ b/packages/language-server/src/completion/completableIndexSelfInvocationExpression.ts
@@ -1,0 +1,39 @@
+import { IndexSelfInvocationExpression } from "@hylimo/core/lib/ast/indexSelfInvocationExpression.js";
+import { InterpreterContext } from "@hylimo/core/lib/runtime/interpreter/interpreterContext.js";
+import { LabeledValue } from "@hylimo/core/lib/runtime/objects/labeledValue.js";
+import { ExecutableAbstractInvocationExpression } from "@hylimo/core/lib/runtime/ast/executableAbstractInvocationExpression.js";
+import { ExecutableListEntry } from "@hylimo/core/lib/runtime/ast/executableListEntry.js";
+import { ExecutableExpression } from "@hylimo/core/lib/runtime/ast/executableExpression.js";
+import { assertIndex } from "@hylimo/core/lib/stdlib/typeHelpers.js";
+import { supplyNamedArguments } from "./completionGenerator.js";
+
+/**
+ * Executable SelfInvocationExpression
+ */
+export class CompletableIndexSelfInvocationExpression extends ExecutableAbstractInvocationExpression<IndexSelfInvocationExpression> {
+    /**
+     * Creates a new ExecutableInvocationExpression consisting of an expression of which the result should be invoked,
+     * and a set of optionally named expressions as arguments
+     *
+     * @param expression the expression this represents
+     * @param argumentExpressions evaluated to provide arguments
+     * @param target evaluated to provide the function to invoke
+     * @param index evaluated to provide the index to access on target
+     */
+    constructor(
+        expression: IndexSelfInvocationExpression | undefined,
+        argumentExpressions: ExecutableListEntry[],
+        readonly target: ExecutableExpression<any>,
+        readonly index: ExecutableExpression<any>
+    ) {
+        super(expression, argumentExpressions);
+    }
+
+    override evaluateInternal(context: InterpreterContext): LabeledValue {
+        const targetValue = this.target.evaluateWithSource(context);
+        const indexValue = this.index.evaluate(context).value;
+        const fieldValue = targetValue.value.getFieldValue(assertIndex(indexValue), context);
+
+        return supplyNamedArguments(fieldValue, targetValue, context, this.argumentExpressions, this.expression!);
+    }
+}

--- a/packages/language-server/src/completion/completableInvocationExpression.ts
+++ b/packages/language-server/src/completion/completableInvocationExpression.ts
@@ -1,0 +1,40 @@
+import { InvocationExpression } from "@hylimo/core/lib/ast/invocationExpression.js";
+import { InterpreterContext } from "@hylimo/core/lib/runtime/interpreter/interpreterContext.js";
+import { LabeledValue } from "@hylimo/core/lib/runtime/objects/labeledValue.js";
+import { ExecutableAbstractInvocationExpression } from "@hylimo/core/lib/runtime/ast/executableAbstractInvocationExpression.js";
+import { ExecutableListEntry } from "@hylimo/core/lib/runtime/ast/executableListEntry.js";
+import { ExecutableExpression } from "@hylimo/core/lib/runtime/ast/executableExpression.js";
+import { supplyNamedArguments } from "./completionGenerator.js";
+
+/**
+ * Executable InvocationExpression
+ */
+export class CompletableInvocationExpression extends ExecutableAbstractInvocationExpression<InvocationExpression> {
+    /**
+     * Creates a new InvocationExpression consisting of an expression of which the result should be invoked,
+     * and a set of optionally named expressions as arguments
+     *
+     * @param expression the expression this represents
+     * @param argumentExpressions evaluated to provide arguments
+     * @param target evaluated to provide the function to invoke
+     */
+    constructor(
+        expression: InvocationExpression | undefined,
+        argumentExpressions: ExecutableListEntry[],
+        readonly target: ExecutableExpression<any>
+    ) {
+        super(expression, argumentExpressions);
+    }
+
+    override evaluateInternal(context: InterpreterContext): LabeledValue {
+        const targetValue = this.target.evaluate(context).value;
+
+        return supplyNamedArguments(
+            targetValue,
+            { value: targetValue },
+            context,
+            this.argumentExpressions,
+            this.expression!
+        );
+    }
+}

--- a/packages/language-server/src/completion/completionAstTransformer.ts
+++ b/packages/language-server/src/completion/completionAstTransformer.ts
@@ -80,7 +80,7 @@ export class CompletionAstTransformer extends RuntimeAstTransformer {
         return super.visitInvocationExpression(expression);
     }
 
-    // Override 'object[0](…)' so that we can autocomplete documented named params declared by '0'
+    // Override 'object["a"](…)' so that we can autocomplete documented named params declared by '0'
     override visitIndexSelfInvocationExpression(expression: IndexSelfInvocationExpression): ExecutableExpression<any> {
         if (this.isEditingArgumentName(expression)) {
             return new CompletableIndexSelfInvocationExpression(
@@ -93,7 +93,7 @@ export class CompletionAstTransformer extends RuntimeAstTransformer {
         return super.visitIndexSelfInvocationExpression(expression);
     }
 
-    // Override 'test["hello"](…)' so that we can autocomplete documented named params declared by 'hello'
+    // Override 'test.hello(…)' so that we can autocomplete documented named params declared by 'hello'
     override visitFieldSelfInvocationExpression(expression: FieldSelfInvocationExpression): ExecutableExpression<any> {
         if (this.isEditingArgumentName(expression)) {
             return new CompletableFieldSelfInvocationExpression(

--- a/packages/language-server/src/completion/completionAstTransformer.ts
+++ b/packages/language-server/src/completion/completionAstTransformer.ts
@@ -1,12 +1,13 @@
 import {
-    AssignmentExpression,
-    CompletionExpressionMetadata,
-    ExecutableNumberLiteralExpression,
-    Expression,
-    FieldAccessExpression,
-    IdentifierExpression,
-    NumberLiteralExpression,
-    FieldSelfInvocationExpression
+  AssignmentExpression,
+  CompletionExpressionMetadata,
+  ExecutableNumberLiteralExpression,
+  Expression,
+  FieldAccessExpression,
+  IdentifierExpression,
+  NumberLiteralExpression,
+  FieldSelfInvocationExpression,
+  IndexSelfInvocationExpression
 } from "@hylimo/core";
 import { ExecutableExpression } from "@hylimo/core";
 import { RuntimeAstTransformer } from "@hylimo/core";
@@ -18,73 +19,92 @@ import { FieldAssignmentExpression } from "@hylimo/core/src/ast/fieldAssignmentE
  * ExecutableCompletionExpressions if they are in the completion range.
  */
 export class CompletionAstTransformer extends RuntimeAstTransformer {
-    /**
-     * Creates a new CompletionAstTransformer
-     *
-     * @param position the position in the source code where the completion is requested
-     */
-    constructor(private readonly position: number) {
-        super(true);
-    }
+  /**
+   * Creates a new CompletionAstTransformer
+   *
+   * @param position the position in the source code where the completion is requested
+   */
+  constructor(private readonly position: number) {
+    super(true);
+  }
 
-    override visitAssignmentExpression(expression: AssignmentExpression): ExecutableExpression<any> {
-        if (this.isInCompletionRange(expression)) {
-            return new ExecutableCompletionExpression(expression, false);
-        } else {
-            return super.visitAssignmentExpression(expression);
-        }
+  override visitAssignmentExpression(expression: AssignmentExpression): ExecutableExpression<any> {
+    if (this.isInCompletionRange(expression)) {
+      return new ExecutableCompletionExpression(expression, false);
+    } else {
+      return super.visitAssignmentExpression(expression);
     }
+  }
 
-    override visitFieldAssignmentExpression(expression: FieldAssignmentExpression): ExecutableExpression<any> {
-        if (this.isInCompletionRange(expression)) {
-            return new ExecutableCompletionExpression(expression, true, this.visit(expression.target));
-        } else {
-            return super.visitFieldAssignmentExpression(expression);
-        }
+  override visitFieldAssignmentExpression(expression: FieldAssignmentExpression): ExecutableExpression<any> {
+    if (this.isInCompletionRange(expression)) {
+      return new ExecutableCompletionExpression(expression, true, this.visit(expression.target));
+    } else {
+      return super.visitFieldAssignmentExpression(expression);
     }
+  }
 
-    override visitFieldAccessExpression(expression: FieldAccessExpression): ExecutableExpression<any> {
-        if (
-            this.isInCompletionRange(expression) &&
-            (!(expression.target instanceof NumberLiteralExpression) || expression.name !== "")
-        ) {
-            return new ExecutableCompletionExpression(expression, true, this.visit(expression.target));
-        } else {
-            return super.visitFieldAccessExpression(expression);
-        }
+  override visitFieldAccessExpression(expression: FieldAccessExpression): ExecutableExpression<any> {
+    if (
+      this.isInCompletionRange(expression) &&
+      (!(expression.target instanceof NumberLiteralExpression) || expression.name !== "")
+    ) {
+      return new ExecutableCompletionExpression(expression, true, this.visit(expression.target));
+    } else {
+      return super.visitFieldAccessExpression(expression);
     }
+  }
 
-    override visitIdentifierExpression(expression: IdentifierExpression): ExecutableExpression<any> {
-        if (this.isInCompletionRange(expression)) {
-            return new ExecutableCompletionExpression(expression, false);
-        } else {
-            return super.visitIdentifierExpression(expression);
-        }
+  override visitIdentifierExpression(expression: IdentifierExpression): ExecutableExpression<any> {
+    if (this.isInCompletionRange(expression)) {
+      return new ExecutableCompletionExpression(expression, false);
+    } else {
+      return super.visitIdentifierExpression(expression);
     }
+  }
 
-    override visitFieldSelfInvocationExpression(expression: FieldSelfInvocationExpression): ExecutableExpression<any> {
-        if (this.isInCompletionRange(expression)) {
-            return new ExecutableCompletionExpression(expression, true, this.visit(expression.target));
-        } else {
-            return super.visitFieldSelfInvocationExpression(expression);
-        }
+  // Override 'test(…)' so that we can autocomplete documented named params declared by 'test'
+  override visitInvocationExpression(expression: InvocationExpression): ExecutableExpression<any> {
+    if (this.isInCompletionRange(expression)) {
+      return new ExecutableCompletionExpression(expression, ;
+    } else {
+      return super.visitInvocationExpression(expression);
     }
+  }
 
-    override visitNoopExpression(): ExecutableExpression<any> {
-        return new ExecutableNumberLiteralExpression(undefined, 0);
+  // Override 'object[0](…)' so that we can autocomplete documented named params declared by '0'
+  override visitIndexSelfInvocationExpression(expression: IndexSelfInvocationExpression): ExecutableExpression<any> {
+    if (this.isInCompletionRange(expression)) {
+      return new ExecutableCompletionExpression(expression, true, ;
+    } else {
+      return super.visitIndexSelfInvocationExpression(expression);
     }
+  }
 
-    /**
-     * Checks if the given expression is in the completion range
-     *
-     * @param expression the expression to check
-     * @returns true if the expression is in the completion range
-     */
-    private isInCompletionRange(expression: Expression<CompletionExpressionMetadata>): boolean {
-        const range = expression.metadata.completionRange;
-        if (range == undefined) {
-            return false;
-        }
-        return range[0] < this.position && this.position <= range[1];
+  // Override 'test["hello"](…)' so that we can autocomplete documented named params declared by 'hello'
+  override visitFieldSelfInvocationExpression(expression: FieldSelfInvocationExpression): ExecutableExpression<any> {
+    if (this.isInCompletionRange(expression)) {
+      return new ExecutableCompletionExpression(expression, true, this.visit(expression.target));
+    } else {
+      return super.visitFieldSelfInvocationExpression(expression);
     }
+  }
+
+  override visitNoopExpression(): ExecutableExpression<any> {
+    return new ExecutableNumberLiteralExpression(undefined, 0);
+  }
+
+  /**
+   * Checks if the given expression is in the completion range
+   *
+   * @param expression the expression to check
+   * @returns true if the expression is in the completion range
+   */
+  private isInCompletionRange(expression: Expression<CompletionExpressionMetadata>): boolean {
+    const range = expression.metadata.completionRange;
+    if (range == undefined) {
+      return false;
+    }
+    return range[0] < this.position && this.position <= range[1];
+  }
 }

--- a/packages/language-server/src/completion/completionAstTransformer.ts
+++ b/packages/language-server/src/completion/completionAstTransformer.ts
@@ -1,110 +1,141 @@
 import {
-  AssignmentExpression,
-  CompletionExpressionMetadata,
-  ExecutableNumberLiteralExpression,
-  Expression,
-  FieldAccessExpression,
-  IdentifierExpression,
-  NumberLiteralExpression,
-  FieldSelfInvocationExpression,
-  IndexSelfInvocationExpression
+    AssignmentExpression,
+    CompletionExpressionMetadata,
+    ExecutableNumberLiteralExpression,
+    Expression,
+    FieldAccessExpression,
+    IdentifierExpression,
+    NumberLiteralExpression,
+    FieldSelfInvocationExpression,
+    IndexSelfInvocationExpression,
+    InvocationExpression,
+    AbstractInvocationExpression
 } from "@hylimo/core";
 import { ExecutableExpression } from "@hylimo/core";
 import { RuntimeAstTransformer } from "@hylimo/core";
 import { ExecutableCompletionExpression } from "./executableCompletionExpression.js";
 import { FieldAssignmentExpression } from "@hylimo/core/src/ast/fieldAssignmentExpression.js";
+import { CompletableIndexSelfInvocationExpression } from "./completableIndexSelfInvocationExpression.js";
+import { CompletableInvocationExpression } from "./completableInvocationExpression.js";
+import { CompletableFieldSelfInvocationExpression } from "./completableFieldSelfInvocationExpression.js";
 
 /**
  * Transforms the AST into an executable AST where completion expressions are replaced with
  * ExecutableCompletionExpressions if they are in the completion range.
  */
 export class CompletionAstTransformer extends RuntimeAstTransformer {
-  /**
-   * Creates a new CompletionAstTransformer
-   *
-   * @param position the position in the source code where the completion is requested
-   */
-  constructor(private readonly position: number) {
-    super(true);
-  }
-
-  override visitAssignmentExpression(expression: AssignmentExpression): ExecutableExpression<any> {
-    if (this.isInCompletionRange(expression)) {
-      return new ExecutableCompletionExpression(expression, false);
-    } else {
-      return super.visitAssignmentExpression(expression);
+    /**
+     * Creates a new CompletionAstTransformer
+     *
+     * @param position the position in the source code where the completion is requested
+     */
+    constructor(private readonly position: number) {
+        super(true);
     }
-  }
 
-  override visitFieldAssignmentExpression(expression: FieldAssignmentExpression): ExecutableExpression<any> {
-    if (this.isInCompletionRange(expression)) {
-      return new ExecutableCompletionExpression(expression, true, this.visit(expression.target));
-    } else {
-      return super.visitFieldAssignmentExpression(expression);
+    override visitAssignmentExpression(expression: AssignmentExpression): ExecutableExpression<any> {
+        if (this.isInCompletionRange(expression)) {
+            return new ExecutableCompletionExpression(expression, false);
+        } else {
+            return super.visitAssignmentExpression(expression);
+        }
     }
-  }
 
-  override visitFieldAccessExpression(expression: FieldAccessExpression): ExecutableExpression<any> {
-    if (
-      this.isInCompletionRange(expression) &&
-      (!(expression.target instanceof NumberLiteralExpression) || expression.name !== "")
-    ) {
-      return new ExecutableCompletionExpression(expression, true, this.visit(expression.target));
-    } else {
-      return super.visitFieldAccessExpression(expression);
+    override visitFieldAssignmentExpression(expression: FieldAssignmentExpression): ExecutableExpression<any> {
+        if (this.isInCompletionRange(expression)) {
+            return new ExecutableCompletionExpression(expression, true, this.visit(expression.target));
+        } else {
+            return super.visitFieldAssignmentExpression(expression);
+        }
     }
-  }
 
-  override visitIdentifierExpression(expression: IdentifierExpression): ExecutableExpression<any> {
-    if (this.isInCompletionRange(expression)) {
-      return new ExecutableCompletionExpression(expression, false);
-    } else {
-      return super.visitIdentifierExpression(expression);
+    override visitFieldAccessExpression(expression: FieldAccessExpression): ExecutableExpression<any> {
+        if (
+            this.isInCompletionRange(expression) &&
+            (!(expression.target instanceof NumberLiteralExpression) || expression.name !== "")
+        ) {
+            return new ExecutableCompletionExpression(expression, true, this.visit(expression.target));
+        } else {
+            return super.visitFieldAccessExpression(expression);
+        }
     }
-  }
 
-  // Override 'test(…)' so that we can autocomplete documented named params declared by 'test'
-  override visitInvocationExpression(expression: InvocationExpression): ExecutableExpression<any> {
-    if (this.isInCompletionRange(expression)) {
-      return new ExecutableCompletionExpression(expression, ;
-    } else {
-      return super.visitInvocationExpression(expression);
+    override visitIdentifierExpression(expression: IdentifierExpression): ExecutableExpression<any> {
+        if (this.isInCompletionRange(expression)) {
+            return new ExecutableCompletionExpression(expression, false);
+        } else {
+            return super.visitIdentifierExpression(expression);
+        }
     }
-  }
 
-  // Override 'object[0](…)' so that we can autocomplete documented named params declared by '0'
-  override visitIndexSelfInvocationExpression(expression: IndexSelfInvocationExpression): ExecutableExpression<any> {
-    if (this.isInCompletionRange(expression)) {
-      return new ExecutableCompletionExpression(expression, true, ;
-    } else {
-      return super.visitIndexSelfInvocationExpression(expression);
+    // Override 'test(…)' so that we can autocomplete documented named params declared by 'test'
+    override visitInvocationExpression(expression: InvocationExpression): ExecutableExpression<any> {
+        if (this.isEditingArgumentName(expression)) {
+            return new CompletableInvocationExpression(
+                this.optionalExpression(expression),
+                this.generateListEntries(expression.argumentExpressions),
+                this.visit(expression.target)
+            );
+        }
+        return super.visitInvocationExpression(expression);
     }
-  }
 
-  // Override 'test["hello"](…)' so that we can autocomplete documented named params declared by 'hello'
-  override visitFieldSelfInvocationExpression(expression: FieldSelfInvocationExpression): ExecutableExpression<any> {
-    if (this.isInCompletionRange(expression)) {
-      return new ExecutableCompletionExpression(expression, true, this.visit(expression.target));
-    } else {
-      return super.visitFieldSelfInvocationExpression(expression);
+    // Override 'object[0](…)' so that we can autocomplete documented named params declared by '0'
+    override visitIndexSelfInvocationExpression(expression: IndexSelfInvocationExpression): ExecutableExpression<any> {
+        if (this.isEditingArgumentName(expression)) {
+            return new CompletableIndexSelfInvocationExpression(
+                this.optionalExpression(expression),
+                this.generateListEntries(expression.argumentExpressions),
+                this.visit(expression.target),
+                this.visit(expression.index)
+            );
+        }
+        return super.visitIndexSelfInvocationExpression(expression);
     }
-  }
 
-  override visitNoopExpression(): ExecutableExpression<any> {
-    return new ExecutableNumberLiteralExpression(undefined, 0);
-  }
-
-  /**
-   * Checks if the given expression is in the completion range
-   *
-   * @param expression the expression to check
-   * @returns true if the expression is in the completion range
-   */
-  private isInCompletionRange(expression: Expression<CompletionExpressionMetadata>): boolean {
-    const range = expression.metadata.completionRange;
-    if (range == undefined) {
-      return false;
+    // Override 'test["hello"](…)' so that we can autocomplete documented named params declared by 'hello'
+    override visitFieldSelfInvocationExpression(expression: FieldSelfInvocationExpression): ExecutableExpression<any> {
+        if (this.isEditingArgumentName(expression)) {
+            return new CompletableFieldSelfInvocationExpression(
+                this.optionalExpression(expression),
+                this.generateListEntries(expression.argumentExpressions),
+                this.visit(expression.target),
+                expression.name
+            );
+        }
+        if (this.isInCompletionRange(expression)) {
+            return new ExecutableCompletionExpression(expression, true, this.visit(expression.target));
+        }
+        return super.visitFieldSelfInvocationExpression(expression);
     }
-    return range[0] < this.position && this.position <= range[1];
-  }
+
+    /**
+     * Checks whether the user is currently editing any of the inner arguments of an expression that may be a named argument (is an identifier).
+     *
+     * @param func the function expression to check
+     * @return true when named arguments should be suggested
+     */
+    isEditingArgumentName(func: AbstractInvocationExpression): boolean {
+        return func.innerArgumentExpressions.some(
+            (arg) => arg.value instanceof IdentifierExpression && this.isInCompletionRange(arg.value)
+        );
+    }
+
+    override visitNoopExpression(): ExecutableExpression<any> {
+        return new ExecutableNumberLiteralExpression(undefined, 0);
+    }
+
+    /**
+     * Checks if the given expression is in the completion range
+     *
+     * @param expression the expression to check
+     * @returns true if the expression is in the completion range
+     */
+    private isInCompletionRange(expression: Expression<CompletionExpressionMetadata>): boolean {
+        const range = expression.metadata.completionRange;
+        if (range == undefined) {
+            return false;
+        }
+        return range[0] < this.position && this.position <= range[1];
+    }
 }

--- a/packages/language-server/src/completion/completionAstTransformer.ts
+++ b/packages/language-server/src/completion/completionAstTransformer.ts
@@ -68,7 +68,9 @@ export class CompletionAstTransformer extends RuntimeAstTransformer {
         }
     }
 
-    // Override 'test(…)' so that we can autocomplete documented named params declared by 'test'
+    /**
+     * Override 'test(…)' so that we can autocomplete documented named params declared by 'test'
+     */
     override visitInvocationExpression(expression: InvocationExpression): ExecutableExpression<any> {
         if (this.isEditingArgumentName(expression)) {
             return new CompletableInvocationExpression(
@@ -80,7 +82,9 @@ export class CompletionAstTransformer extends RuntimeAstTransformer {
         return super.visitInvocationExpression(expression);
     }
 
-    // Override 'object["a"](…)' so that we can autocomplete documented named params declared by '0'
+    /**
+     * Override 'this["test"](…)' so that we can autocomplete documented named params declared by 'test'
+     */
     override visitIndexSelfInvocationExpression(expression: IndexSelfInvocationExpression): ExecutableExpression<any> {
         if (this.isEditingArgumentName(expression)) {
             return new CompletableIndexSelfInvocationExpression(
@@ -93,7 +97,9 @@ export class CompletionAstTransformer extends RuntimeAstTransformer {
         return super.visitIndexSelfInvocationExpression(expression);
     }
 
-    // Override 'test.hello(…)' so that we can autocomplete documented named params declared by 'hello'
+    /**
+     * Override 'test.hello(…)' so that we can autocomplete documented named params declared by 'hello'
+     */
     override visitFieldSelfInvocationExpression(expression: FieldSelfInvocationExpression): ExecutableExpression<any> {
         if (this.isEditingArgumentName(expression)) {
             return new CompletableFieldSelfInvocationExpression(

--- a/packages/language-server/src/completion/completionEngine.ts
+++ b/packages/language-server/src/completion/completionEngine.ts
@@ -25,6 +25,7 @@ export class CompletionEngine {
      * Generates completion items based on the given text and position
      *
      * @param text the code to execute
+     * @param additionalExpressions additionally available variables for use in the completion that are not located within the given text
      * @param position the position of the cursor
      * @returns the generated complete items or undefined if no items could be generated
      */

--- a/packages/language-server/src/completion/completionError.ts
+++ b/packages/language-server/src/completion/completionError.ts
@@ -1,4 +1,5 @@
 import { CompletionItem } from "./completionItem.js";
+import { Range } from "@hylimo/core";
 
 /**
  * An error which aborts the execution of the program and provides the context for completion
@@ -9,7 +10,10 @@ export class CompletionError extends Error {
      *
      * @param completionItems the items to provide for completion
      */
-    constructor(readonly completionItems: CompletionItem[]) {
+    constructor(
+        readonly completionItems: CompletionItem[],
+        readonly completionRange: Range
+    ) {
         super();
     }
 
@@ -20,6 +24,6 @@ export class CompletionError extends Error {
      * @returns true if the error is an CompletionError
      */
     static isCompletionError(error: any): error is CompletionError {
-        return "completionItems" in error;
+        return "completionItems" in error && "completionRange" in error;
     }
 }

--- a/packages/language-server/src/completion/completionError.ts
+++ b/packages/language-server/src/completion/completionError.ts
@@ -9,6 +9,7 @@ export class CompletionError extends Error {
      * Creates a new CompletionError
      *
      * @param completionItems the items to provide for completion
+     * @param completionRange the range in which the completion should occur
      */
     constructor(
         readonly completionItems: CompletionItem[],

--- a/packages/language-server/src/completion/completionGenerator.ts
+++ b/packages/language-server/src/completion/completionGenerator.ts
@@ -1,0 +1,102 @@
+import {
+    AbstractFunctionObject,
+    AbstractInvocationExpression,
+    BaseObject,
+    ExecutableAbstractFunctionExpression,
+    ExecutableConstExpression,
+    ExecutableListEntry,
+    InterpreterContext,
+    LabeledValue,
+    SemanticFieldNames
+} from "@hylimo/core";
+import { CompletionError } from "./completionError.js";
+import { CompletionItem } from "./completionItem.js";
+import { FullObject } from "@hylimo/core/lib/runtime/objects/fullObject.js";
+import { CompletionItemKind, InsertTextFormat, InsertTextMode, MarkupKind } from "vscode-languageserver";
+import { Range } from "@hylimo/core";
+
+/**
+ * If the given func throws an error during execution, the LSP tries to autocomplete the named parameters of this function
+ *
+ * @param func the function to be called
+ * @param target where the function is being called on (i.e. `THIS.hi()`
+ * @param context the current context
+ * @param args the arguments of this function
+ * @param expression the executed invocation expression
+ */
+export function supplyNamedArguments(
+    func: BaseObject,
+    target: LabeledValue,
+    context: InterpreterContext,
+    args: ExecutableListEntry[],
+    expression: AbstractInvocationExpression
+): LabeledValue {
+    try {
+        return func.invoke(
+            [{ value: new ExecutableConstExpression(target), name: SemanticFieldNames.SELF }, ...args],
+            context,
+            undefined,
+            expression
+        );
+    } catch (error: any) {
+        if (CompletionError.isCompletionError(error) && func instanceof AbstractFunctionObject) {
+            error.completionItems.push(...getNamedArgs(func, context, error));
+        }
+
+        throw error;
+    }
+}
+
+/**
+ * Computes completion items for the named arguments of the currently executed function.
+ *
+ * @param func the currently interpreted function
+ * @param context the current context
+ * @param error the error that was thrown beforehand
+ */
+function getNamedArgs(
+    func: AbstractFunctionObject<ExecutableAbstractFunctionExpression<any>>,
+    context: InterpreterContext,
+    error: CompletionError
+): CompletionItem[] {
+    if (!(func.docs instanceof FullObject)) return [];
+
+    const params = func.docs.getFieldValue("params", context);
+    if (!(params instanceof FullObject)) return [];
+
+    return [...params.fields.entries()]
+        .filter(([key, entry]) => key !== SemanticFieldNames.PROTO && !entry.value.isNull)
+        .filter(([key, _]) => typeof key === "string")
+        .map(([param, description]) =>
+            createNamedArgCompletionItem(param, description.value.toString(context), error.completionRange)
+        );
+}
+
+/**
+ * Creates a completion item for a named argument.<br>
+ * Due to the way the autocompletion works, we need to replace the whole function until this point with the given text:<br>
+ * For example, for `class("Hello", abst` we must replace the whole block with `class("Hello", abstract = `
+ *
+ * @param arg the full function parameter to autocomplete
+ * @param argDocs the documentation of this parameter
+ * @param range the range of the parameter to replace
+ * @returns the completion item
+ */
+function createNamedArgCompletionItem(arg: string | number, argDocs: string, range: Range): CompletionItem {
+    const text = `${arg} = `;
+    return {
+        label: arg.toString(),
+        detail: arg.toString(),
+        documentation: {
+            kind: MarkupKind.Markdown,
+            value: argDocs
+        },
+        textEdit: {
+            range,
+            text: text
+        },
+        kind: CompletionItemKind.Variable,
+        insertTextFormat: InsertTextFormat.PlainText,
+        insertTextMode: InsertTextMode.asIs
+    };
+}

--- a/packages/language-server/src/completion/completionGenerator.ts
+++ b/packages/language-server/src/completion/completionGenerator.ts
@@ -48,21 +48,26 @@ export function supplyNamedArguments(
 }
 
 /**
- * Computes completion items for the named arguments of the currently executed function.
+ * Computes completion items for the documented named arguments of the currently executed function.
  *
  * @param func the currently interpreted function
  * @param context the current context
  * @param error the error that was thrown beforehand
+ * @return the completion items generated from the documented named arguments of this function
  */
 function getNamedArgs(
     func: AbstractFunctionObject<ExecutableAbstractFunctionExpression<any>>,
     context: InterpreterContext,
     error: CompletionError
 ): CompletionItem[] {
-    if (!(func.docs instanceof FullObject)) return [];
+    if (!(func.docs instanceof FullObject)) {
+        return [];
+    }
 
     const params = func.docs.getFieldValue("params", context);
-    if (!(params instanceof FullObject)) return [];
+    if (!(params instanceof FullObject)) {
+        return [];
+    }
 
     return [...params.fields.entries()]
         .filter(([key, entry]) => key !== SemanticFieldNames.PROTO && !entry.value.isNull)

--- a/packages/language-server/src/completion/completionGenerator.ts
+++ b/packages/language-server/src/completion/completionGenerator.ts
@@ -23,6 +23,7 @@ import { Range } from "@hylimo/core";
  * @param context the current context
  * @param args the arguments of this function
  * @param expression the executed invocation expression
+ * @return the result returned by the function in case it completed normally
  */
 export function supplyNamedArguments(
     func: BaseObject,

--- a/packages/language-server/src/completion/completionItem.ts
+++ b/packages/language-server/src/completion/completionItem.ts
@@ -2,7 +2,7 @@ import { Range } from "@hylimo/core";
 import { CompletionItem as LspCompletionItem } from "vscode-languageserver";
 
 /**
- * Completion item with a text edit based on a AST range (instead of a LSP range)
+ * Completion item with a text edit based on an AST range (instead of an LSP range)
  */
 export type CompletionItem = Omit<LspCompletionItem, "textEdit"> & {
     textEdit: {

--- a/packages/language-server/src/completion/executableCompletionExpression.ts
+++ b/packages/language-server/src/completion/executableCompletionExpression.ts
@@ -1,9 +1,14 @@
-import { Range, Expression, FullObject, SemanticFieldNames } from "@hylimo/core";
-import { CompletionExpressionMetadata } from "@hylimo/core";
-import { ExecutableExpression } from "@hylimo/core";
-import { InterpreterContext } from "@hylimo/core";
-import { BaseObject } from "@hylimo/core";
-import { AbstractFunctionObject } from "@hylimo/core";
+import {
+    AbstractFunctionObject,
+    BaseObject,
+    CompletionExpressionMetadata,
+    ExecutableExpression,
+    Expression,
+    FullObject,
+    InterpreterContext,
+    Range,
+    SemanticFieldNames
+} from "@hylimo/core";
 import { CompletionError } from "./completionError.js";
 import { CompletionItemKind, InsertTextFormat, InsertTextMode, MarkupKind } from "vscode-languageserver";
 import { CompletionItem } from "./completionItem.js";
@@ -35,9 +40,15 @@ export class ExecutableCompletionExpression extends ExecutableExpression<Express
     override evaluateInternal(context: InterpreterContext): never {
         if (this.context != undefined) {
             const completionContext = this.context.evaluate(context);
-            throw new CompletionError(this.transformCompletionContext(completionContext.value, context));
+            throw new CompletionError(
+                this.transformCompletionContext(completionContext.value, context),
+                this.expression!.metadata.completionRange
+            );
         } else {
-            throw new CompletionError(this.transformCompletionContext(context.currentScope, context));
+            throw new CompletionError(
+                this.transformCompletionContext(context.currentScope, context),
+                this.expression!.metadata.completionRange
+            );
         }
     }
 
@@ -62,7 +73,7 @@ export class ExecutableCompletionExpression extends ExecutableExpression<Express
                 kind = isFunction ? CompletionItemKind.Function : CompletionItemKind.Variable;
             }
             const range = this.expression!.metadata.completionRange;
-            items.push(this.createCompletionItem(key, docs, range, kind));
+            items.push(this.createIdentifierCompletionItem(key, docs, range, kind));
             if (snippet != undefined) {
                 items.push(this.createSnippetCompletionItem(key, docs, snippet, range));
             }
@@ -189,7 +200,7 @@ export class ExecutableCompletionExpression extends ExecutableExpression<Express
      * @param kind the kind of the completion item
      * @returns the completion item
      */
-    private createCompletionItem(
+    private createIdentifierCompletionItem(
         key: string | number,
         docs: string,
         range: Range,


### PR DESCRIPTION
To do so, your named function argument must have docs.
If it has no docs, it won't be autocomplete.

How to reproduce this feature:
```ts
    test = { args.xy }
    test.docs = [
        params = [
        abstract = "Nothing to see",
        y = "Another param"
       ]
    ]

    // type 'a' within the function calls below to see the autocompletion
    this.test()
    this["test"]()
    test()
```
Fixes #42