### PR TITLE
configure skipWaiting and clientsClaim

### DIFF
--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -151,7 +151,9 @@ export default withPwa(
                 file_handlers: [{ action: "./", accept: { "text/*": [".hyl"] } }]
             },
             workbox: {
-                maximumFileSizeToCacheInBytes: 10 * 1024 ** 2
+                maximumFileSizeToCacheInBytes: 10 * 1024 ** 2,
+                skipWaiting: true,
+                clientsClaim: true
             },
             devOptions: {
                 enabled: true,


### PR DESCRIPTION
fixes broken auto-reload (currently without Ctrl + F5 you never get the new version of the page)