### PR TITLE
mostly working underline and strikethrough support

### DIFF
--- a/packages/diagram-common/src/model/elements/base/colored.ts
+++ b/packages/diagram-common/src/model/elements/base/colored.ts
@@ -13,9 +13,9 @@ export interface Colored {
 }
 
 /**
- * A stroke
+ * A basic stroke without line join, cap or miter limit information
  */
-export interface Stroke extends Colored {
+export interface SimpleStroke extends Colored {
     /**
      * The width of the stroke
      */
@@ -28,6 +28,12 @@ export interface Stroke extends Colored {
      * The space between dashes, defaults to strokeDash
      */
     dashSpace?: number;
+}
+
+/**
+ * A stroke
+ */
+export interface Stroke extends SimpleStroke {
     /**
      * Defines how segments are joined together
      */

--- a/packages/diagram-common/src/model/elements/text.ts
+++ b/packages/diagram-common/src/model/elements/text.ts
@@ -1,3 +1,4 @@
+import { SimpleStroke } from "./base/colored.js";
 import { Element } from "./base/element.js";
 import { FilledElement } from "./base/filledElement.js";
 import { LayoutedElement } from "./base/layoutedElement.js";
@@ -20,6 +21,29 @@ export interface Text extends LayoutedElement, FilledElement {
      * Text size
      */
     fontSize: number;
+    /**
+     * The underline to apply to the text, if any
+     */
+    underline?: TextLine;
+    /**
+     * The strikethrough to apply to the text, if any
+     */
+    strikethrough?: TextLine;
+}
+
+/**
+ * A line (underline or strikethrough) to apply to text
+ * The x position and width is obtained from the containing text element
+ */
+export interface TextLine extends SimpleStroke {
+    /**
+     * The y position of the line
+     */
+    y: number;
+    /**
+     * The thickness of the line
+     */
+    width: number;
 }
 
 /**

--- a/packages/diagram-common/src/model/simplified/simplifiedDiagramVisitor.ts
+++ b/packages/diagram-common/src/model/simplified/simplifiedDiagramVisitor.ts
@@ -199,6 +199,7 @@ export class DiagramSimplifier {
      * Simplifies a text line (underline or strikethrough) by converting it to a path
      *
      * @param text the text element containing the line
+     * @param line the line to convert
      * @returns the simplified path
      */
     private convertTextLineToPath(text: Text, line: TextLine): Path {

--- a/packages/diagram-common/src/model/simplified/simplifiedDiagramVisitor.ts
+++ b/packages/diagram-common/src/model/simplified/simplifiedDiagramVisitor.ts
@@ -5,13 +5,14 @@ import { MarkerLayoutInformation } from "../elements/canvas/marker.js";
 import { Path } from "../elements/path.js";
 import { Rect } from "../elements/rect.js";
 import { Root } from "../elements/root.js";
-import { SimplifiedCanvasElement } from "./simplifiedTypes.js";
+import { SimplifiedCanvasElement, SimplifiedText } from "./simplifiedTypes.js";
 import { Element } from "../elements/base/element.js";
-import { Text } from "../elements/text.js";
+import { TextLine, Text } from "../elements/text.js";
 import { CanvasConnection } from "../elements/canvas/canvasConnection.js";
 import { Point } from "../../common/point.js";
 import { LayoutedElement } from "../elements/base/layoutedElement.js";
 import { Ellipse } from "../elements/ellipse.js";
+import { LineCap, LineJoin } from "../elements/base/colored.js";
 
 /**
  * Helper class to simplify a diagram.
@@ -57,11 +58,12 @@ export class DiagramSimplifier {
             }
             case Rect.TYPE:
             case Path.TYPE:
-            case Text.TYPE:
             case Ellipse.TYPE:
                 return this.simplifyLayoutedElement(element as LayoutedElement);
             case Canvas.TYPE:
                 return this.simplifyCanvas(element as Canvas);
+            case Text.TYPE:
+                return this.simplifyText(element as Text);
             default:
                 throw new Error(`Unknown element type: ${element.type}`);
         }
@@ -172,6 +174,52 @@ export class DiagramSimplifier {
             edits: {}
         };
     }
+
+    /**
+     * Simplifies a text element by converting the underline and strikethrough to paths
+     *
+     * @param text the text element to simplify
+     * @returns the simplified text element
+     */
+    private simplifyText(text: Text): SimplifiedText {
+        const children = text.children.map(this.simplify.bind(this));
+        if (text.underline != undefined) {
+            children.push(this.convertTextLineToPath(text, text.underline));
+        }
+        if (text.strikethrough != undefined) {
+            children.push(this.convertTextLineToPath(text, text.strikethrough));
+        }
+        return {
+            ...text,
+            children
+        };
+    }
+
+    /**
+     * Simplifies a text line (underline or strikethrough) by converting it to a path
+     *
+     * @param text the text element containing the line
+     * @returns the simplified path
+     */
+    private convertTextLineToPath(text: Text, line: TextLine): Path {
+        return {
+            type: Path.TYPE,
+            id: `simplified_${this.idCounter++}`,
+            x: text.x,
+            y: text.y,
+            width: text.width,
+            height: text.height,
+            children: [],
+            edits: {},
+            path: `M 0 ${line.y} L ${text.width} ${line.y}`,
+            stroke: {
+                ...line,
+                lineJoin: LineJoin.Bevel,
+                lineCap: LineCap.Butt,
+                miterLimit: 1
+            }
+        };
+    }
 }
 
 /**
@@ -243,9 +291,9 @@ class SimpleCanvasLayoutEngine extends CanvasLayoutEngine {
     private readonly parentLookup = new Map<string, string>();
 
     /**
-     * Creates a new CanvasLayoutEngine based on the given children of a canvas
+     * Creates a new CanvasLayoutEngine based on the given root element
      *
-     * @param children the children of a canvas
+     * @param root the root element of the diagram
      */
     constructor(root: Root) {
         super();

--- a/packages/diagram-common/src/model/simplified/simplifiedTypes.ts
+++ b/packages/diagram-common/src/model/simplified/simplifiedTypes.ts
@@ -1,5 +1,6 @@
 import { Point } from "../../common/point.js";
 import { CanvasElement } from "../elements/canvas/canvasElement.js";
+import { Text } from "../elements/text.js";
 
 /**
  * Simplified version of CanvasElement where pos is replaced with the actual point
@@ -14,3 +15,8 @@ export interface SimplifiedCanvasElement
      */
     pos: Point;
 }
+
+/**
+ * Simplified version of Text where underline and strikethrough are removed
+ */
+export type SimplifiedText = Omit<Text, "underline" | "strikethrough">;

--- a/packages/diagram-render-pdf/src/pdfRenderer.ts
+++ b/packages/diagram-render-pdf/src/pdfRenderer.ts
@@ -8,7 +8,7 @@ import {
     Shape,
     SimplifiedCanvasElement,
     SimplifiedDiagramVisitor,
-    Text
+    SimplifiedText
 } from "@hylimo/diagram-common";
 import PDFDocument from "pdfkit/js/pdfkit.standalone.js";
 import { create } from "fontkit";
@@ -139,7 +139,7 @@ export class PDFDiagramVisitor extends SimplifiedDiagramVisitor<PDFKit.PDFDocume
         }
     }
 
-    override visitText(element: Text, context: PDFKit.PDFDocument): void {
+    override visitText(element: SimplifiedText, context: PDFKit.PDFDocument): void {
         context.fontSize(element.fontSize);
         context.font(element.fontFamily, element.fontSize);
         const fillAttributes = extractFillAttributes(element);
@@ -149,6 +149,7 @@ export class PDFDiagramVisitor extends SimplifiedDiagramVisitor<PDFKit.PDFDocume
             lineBreak: false,
             baseline: "alphabetic"
         });
+        this.visitChildren(element, context);
     }
 
     override visitCanvas(element: Canvas, context: PDFKit.PDFDocument): void {

--- a/packages/diagram-render-svg/src/svgRenderer.ts
+++ b/packages/diagram-render-svg/src/svgRenderer.ts
@@ -1,4 +1,13 @@
-import { Root, Rect, Path, Text, Canvas, Element, convertFontsToCssStyle, Ellipse } from "@hylimo/diagram-common";
+import {
+    Root,
+    Rect,
+    Path,
+    Canvas,
+    Element,
+    convertFontsToCssStyle,
+    Ellipse,
+    SimplifiedText
+} from "@hylimo/diagram-common";
 import { SimplifiedDiagramVisitor } from "@hylimo/diagram-common";
 import {
     extractFillAttributes,
@@ -160,7 +169,7 @@ class SVGDiagramVisitor extends SimplifiedDiagramVisitor<undefined, SVGNode[]> {
         return [result];
     }
 
-    override visitText(element: Text): SVGNode[] {
+    override visitText(element: SimplifiedText): SVGNode[] {
         const result: SVGNode = {
             type: "text",
             children: [element.text],
@@ -169,7 +178,7 @@ class SVGDiagramVisitor extends SimplifiedDiagramVisitor<undefined, SVGNode[]> {
             "font-family": element.fontFamily,
             "font-size": element.fontSize
         };
-        return [result];
+        return [result, ...this.visitChildren(element)];
     }
 
     override visitCanvas(element: Canvas): SVGNode[] {

--- a/packages/diagram-ui/src/model/sText.ts
+++ b/packages/diagram-ui/src/model/sText.ts
@@ -1,4 +1,4 @@
-import { Fill, FontStyle, FontWeight, Text } from "@hylimo/diagram-common";
+import { Fill, TextLine, FontStyle, FontWeight, Text } from "@hylimo/diagram-common";
 import { LinearAnimatable } from "../features/animation/model.js";
 import { SLayoutedElement } from "./sLayoutedElement.js";
 
@@ -37,4 +37,12 @@ export class SText extends SLayoutedElement implements Text, LinearAnimatable {
      * normal or italic style
      */
     fontStyle!: FontStyle;
+    /**
+     * The underline to apply to the text, if any
+     */
+    underline?: TextLine;
+    /**
+     * The strikethrough to apply to the text, if any
+     */
+    strikethrough?: TextLine;
 }

--- a/packages/diagram-ui/src/views/textView.ts
+++ b/packages/diagram-ui/src/views/textView.ts
@@ -2,7 +2,8 @@ import { injectable } from "inversify";
 import { VNode } from "snabbdom";
 import { IViewArgs, RenderingContext, IView, svg } from "sprotty";
 import { SText } from "../model/sText.js";
-import { extractFillAttributes, extractLayoutAttributes } from "@hylimo/diagram-render-svg";
+import { extractFillAttributes, extractLayoutAttributes, StrokeAttributes } from "@hylimo/diagram-render-svg";
+import { TextLine } from "@hylimo/diagram-common";
 
 /**
  * IView that represents an svg text
@@ -10,19 +11,63 @@ import { extractFillAttributes, extractLayoutAttributes } from "@hylimo/diagram-
 @injectable()
 export class TextView implements IView {
     render(model: Readonly<SText>, _context: RenderingContext, _args?: IViewArgs | undefined): VNode | undefined {
-        return svg(
-            "text",
-            {
-                attrs: {
-                    ...extractLayoutAttributes(model),
-                    ...extractFillAttributes(model),
-                    "font-family": model.fontFamily,
-                    "font-size": model.fontSize,
-                    "font-style": model.fontStyle,
-                    "font-weight": model.fontWeight
-                }
-            },
-            model.text
+        const elements: VNode[] = [];
+        const fillAttributes = extractFillAttributes(model);
+        elements.push(
+            svg(
+                "text",
+                {
+                    attrs: {
+                        ...extractLayoutAttributes(model),
+                        ...fillAttributes,
+                        "font-family": model.fontFamily,
+                        "font-size": model.fontSize,
+                        "font-style": model.fontStyle,
+                        "font-weight": model.fontWeight
+                    }
+                },
+                model.text
+            )
         );
+        if (model.underline != undefined) {
+            elements.push(this.drawLine(model, model.underline));
+        }
+        if (model.strikethrough != undefined) {
+            elements.push(this.drawLine(model, model.strikethrough));
+        }
+        if (elements.length == 1) {
+            return elements[0];
+        } else {
+            return svg("g", {}, ...elements);
+        }
+    }
+
+    /**
+     * Draws a line for the given font line (underline or strikethrough)
+     *
+     * @param model the text model
+     * @param line the line to draw
+     * @returns the line as a VNode
+     */
+    private drawLine(model: Readonly<SText>, line: TextLine): VNode {
+        const strokeAttributes: StrokeAttributes = {
+            stroke: line.color
+        };
+        if (line.opacity != 1) {
+            strokeAttributes["stroke-opacity"] = line.opacity;
+        }
+        strokeAttributes["stroke-width"] = line.width;
+        if (line.dash != undefined) {
+            strokeAttributes["stroke-dasharray"] = `${line.dash} ${line.dashSpace ?? line.dash}`;
+        }
+        return svg("line", {
+            attrs: {
+                x1: model.x,
+                x2: model.x + model.width,
+                y1: model.y + line.y,
+                y2: model.y + line.y,
+                ...strokeAttributes
+            }
+        });
     }
 }

--- a/packages/diagram/src/layout/elements/attributes.ts
+++ b/packages/diagram/src/layout/elements/attributes.ts
@@ -132,7 +132,7 @@ export function extractStrokeStyleAttributes(styles: Record<string, any>): Pick<
                 dashSpace: styles.strokeDashSpace ?? styles.strokeDash,
                 lineCap: styles.strokeLineCap ?? LineCap.Butt,
                 lineJoin: styles.strokeLineJoin ?? LineJoin.Miter,
-                miterLimit: styles.strokeMiterLimit ?? 4
+                miterLimit: Math.max(styles.strokeMiterLimit ?? 4, 1)
             }
         };
     } else {

--- a/packages/diagram/src/layout/elements/spanLayoutConfig.ts
+++ b/packages/diagram/src/layout/elements/spanLayoutConfig.ts
@@ -1,4 +1,4 @@
-import { enumType, FullObject, nullType, numberType, stringType } from "@hylimo/core";
+import { booleanType, enumType, FullObject, nullType, numberType, or, stringType } from "@hylimo/core";
 import { Element, FontStyle, FontWeight, Point, Size } from "@hylimo/diagram-common";
 import { ContentCardinality, LayoutElement, SizeConstraints } from "../layoutElement.js";
 import { Layout } from "../engine/layout.js";
@@ -36,6 +36,49 @@ export class SpanLayoutConfig extends ElementLayoutConfig {
                     name: "fontStyle",
                     description: 'optional font style, if given must be either "normal" or "italic"',
                     type: enumType(FontStyle)
+                },
+                {
+                    name: "underline",
+                    description: "optional underline, must be a valid color string or boolean (fill color used)",
+                    type: or(stringType, booleanType)
+                },
+                {
+                    name: "underlineOpacity",
+                    description: "optional underline opacity, must be a number between 0 and 1",
+                    type: numberType
+                },
+                { name: "underlineWidth", description: "optional width of the underline", type: numberType },
+                {
+                    name: "underlineDash",
+                    description: "optional dash length. If not set, underline is solid.",
+                    type: numberType
+                },
+                {
+                    name: "underlineDashSpace",
+                    description: "space between dashes, only used if underlineDash is set, defaults to underlineDash",
+                    type: numberType
+                },
+                {
+                    name: "strikethrough",
+                    description: "optional strikethrough, must be a valid color string or boolean (fill color used)",
+                    type: or(stringType, booleanType)
+                },
+                {
+                    name: "strikethroughOpacity",
+                    description: "optional strikethrough opacity, must be a number between 0 and 1",
+                    type: numberType
+                },
+                { name: "strikethroughWidth", description: "optional width of the strikethrough", type: numberType },
+                {
+                    name: "strikethroughDash",
+                    description: "optional dash length. If not set, strikethrough is solid.",
+                    type: numberType
+                },
+                {
+                    name: "strikethroughDashSpace",
+                    description:
+                        "space between dashes, only used if strikethroughDash is set, defaults to strikethroughDash",
+                    type: numberType
                 }
             ]
         );

--- a/packages/diagram/src/layout/font/textLayouter.ts
+++ b/packages/diagram/src/layout/font/textLayouter.ts
@@ -1,8 +1,9 @@
 import LineBreaker, { Break } from "linebreak";
 import { LayoutElement } from "../layoutElement.js";
-import { Text, Size, FontWeight, FontStyle } from "@hylimo/diagram-common";
+import { Text, Size, FontWeight, FontStyle, TextLine } from "@hylimo/diagram-common";
 import { FontCollection } from "./fontCollection.js";
 import { extractFillStyleAttributes } from "../elements/attributes.js";
+import { Font } from "fontkit";
 
 /**
  * Result of a text layout process
@@ -32,127 +33,285 @@ export class TextLayouter {
      * @returns the size it needs
      */
     layout(text: LayoutElement, fonts: FontCollection, maxWidth: number): TextLayoutResult {
-        let usedMaxWidth = 0;
-        let offsetX = 0;
-        let offsetY = 0;
-        let currentAscent = 0;
-        let currentDescent = 0;
-        const elements: Text[] = [];
-        let lineEmpty = true;
-        let textOffset = 0;
-        let currentTextElements: Text[] = [];
-        let fontAscent = 0;
-        let fontDescent = 0;
-        const doBreak = () => {
-            offsetX = 0;
-            offsetY += currentAscent;
-            for (const elementToAdd of currentTextElements) {
-                elementToAdd.y = offsetY;
-                elements.push(elementToAdd);
+        const layoutInstance = new TextLayoutInstance(text, fonts, maxWidth);
+        return layoutInstance.layout();
+    }
+}
+
+/**
+ * Context in which a text element is created
+ */
+interface TextContext {
+    /**
+     * The styles applyed to the current span
+     */
+    styles: any;
+    /**
+     * The name of the current font
+     */
+    fontFamily: string;
+    /**
+     * The current font
+     */
+    font: Font;
+    /**
+     * The scaling factor applied to font design units
+     */
+    scalingFactor: number;
+}
+
+/**
+ * A text layout instance
+ */
+class TextLayoutInstance {
+    /**
+     * The actually used width
+     */
+    private usedWidth = 0;
+    /**
+     * The current x offset
+     */
+    private offsetX = 0;
+    /**
+     * The current y offset
+     */
+    private offsetY = 0;
+    /**
+     * Ascent (and half line gap) of the current line
+     */
+    private currentAscent = 0;
+    /**
+     * Descent (and half line gap) of the current line
+     */
+    private currentDescent = 0;
+    /**
+     * Finalized text elements
+     */
+    private readonly elements: Text[] = [];
+    /**
+     * Whether the current line is empty
+     */
+    private lineEmpty = true;
+    /**
+     * Offset for the current text element
+     */
+    private textOffset = 0;
+    /**
+     * The text elements in the current line
+     */
+    private currentTextElements: Text[] = [];
+    /**
+     * The ascent (and half line gap) of the current font
+     */
+    private fontAscent = 0;
+    /**
+     * The descent (and half line gap) of the current font
+     */
+    private fontDescent = 0;
+    /**
+     * Context required to add a text element
+     */
+    private currentTextContext?: TextContext;
+
+    /**
+     * Creates a new text layouter instance
+     *
+     * @param text the text to layout
+     * @param fonts font collection of all required fonts
+     * @param maxWidth the maximum width available
+     */
+    constructor(
+        private readonly text: LayoutElement,
+        private readonly fonts: FontCollection,
+        private readonly maxWidth: number
+    ) {}
+
+    /**
+     * Layouts the text element
+     *
+     * @returns the layout result
+     */
+    layout(): TextLayoutResult {
+        for (const span of this.text.children as LayoutElement[]) {
+            this.layoutSpan(span);
+        }
+        this.doBreak();
+        return {
+            elements: this.elements,
+            size: {
+                width: this.usedWidth,
+                height: this.offsetY
             }
-            currentTextElements = [];
-            offsetY += currentDescent;
-            lineEmpty = true;
-            currentAscent = 0;
-            currentDescent = 0;
-            textOffset = 0;
         };
-        const addTextElement = (text: string, styles: any, fontFamily: string) => {
-            usedMaxWidth = Math.max(usedMaxWidth, offsetX);
-            currentAscent = Math.max(currentAscent, fontAscent);
-            currentDescent = Math.max(currentDescent, fontDescent);
-            currentTextElements.push({
-                type: Text.TYPE,
-                text,
-                ...extractFillStyleAttributes(styles),
-                fontFamily,
-                fontSize: styles.fontSize,
-                id: "",
-                x: textOffset,
-                y: offsetY,
-                width: 0,
-                height: 0,
-                children: [],
-                edits: {}
-            });
-            lineEmpty = false;
-            textOffset = offsetX;
-        };
-        for (const span of text.children as LayoutElement[]) {
-            const styles = span.styles;
-            const textContent = styles.text as string;
-            const lineBreaker = new LineBreaker(textContent + " ");
-            let lineBreak: Break | null = lineBreaker.nextBreak();
-            const { font, id: fontFamily } = fonts.getFont(
-                styles.fontFamily,
-                styles.fontWeight ?? FontWeight.Normal,
-                styles.fontStyle ?? FontStyle.Normal
-            );
-            const scalingFactor = styles.fontSize / font.unitsPerEm;
-            fontAscent = scalingFactor * (font.ascent + font.lineGap / 2);
-            fontDescent = scalingFactor * (-font.descent + font.lineGap / 2);
-            const glyphRun = font.layout(textContent);
-            let textContentStart = 0;
-            let textContentOffset = 0;
-            let lastBreakOpportunityTextContentOffset = 0;
-            let lastBreakOpportunity = -1;
-            let lastBreakOpportunityOffsetX = 0;
-            for (let i = 0; i < glyphRun.glyphs.length; i++) {
-                const glyph = glyphRun.glyphs[i];
-                let advanceWidth: number;
-                if (textContent[textContentOffset] === "\n") {
-                    advanceWidth = 0;
-                } else {
-                    advanceWidth = glyph.advanceWidth * scalingFactor;
-                }
-                if (offsetX + advanceWidth > maxWidth) {
-                    if (!lineEmpty) {
-                        if (lastBreakOpportunityTextContentOffset > 0) {
-                            offsetX = lastBreakOpportunityOffsetX;
-                            addTextElement(
-                                textContent.substring(textContentStart, lastBreakOpportunityTextContentOffset),
-                                styles,
-                                fontFamily
-                            );
-                            textContentStart = lastBreakOpportunityTextContentOffset;
-                        }
-                        doBreak();
-                        i = lastBreakOpportunity;
-                        textContentOffset = lastBreakOpportunityTextContentOffset;
-                        continue;
-                    } else if (i > 0) {
-                        addTextElement(textContent.substring(textContentStart, i), styles, fontFamily);
-                        doBreak();
-                        textContentStart = i;
+    }
+
+    /**
+     * Layouts a single span
+     *
+     * @param span the span to layout
+     */
+    private layoutSpan(span: LayoutElement) {
+        const styles = span.styles;
+        const textContent = styles.text as string;
+        const lineBreaker = new LineBreaker(textContent + " ");
+        let lineBreak: Break | null = lineBreaker.nextBreak();
+        const { font, id: fontFamily } = this.fonts.getFont(
+            styles.fontFamily,
+            styles.fontWeight ?? FontWeight.Normal,
+            styles.fontStyle ?? FontStyle.Normal
+        );
+        const scalingFactor = styles.fontSize / font.unitsPerEm;
+        this.currentTextContext = { styles, fontFamily, font, scalingFactor };
+        this.fontAscent = scalingFactor * (font.ascent + font.lineGap / 2);
+        this.fontDescent = scalingFactor * (-font.descent + font.lineGap / 2);
+        const glyphRun = font.layout(textContent);
+        let textContentStart = 0;
+        let textContentOffset = 0;
+        let lastBreakOpportunityTextContentOffset = 0;
+        let lastBreakOpportunity = -1;
+        let lastBreakOpportunityOffsetX = 0;
+        for (let i = 0; i < glyphRun.glyphs.length; i++) {
+            const glyph = glyphRun.glyphs[i];
+            let advanceWidth: number;
+            if (textContent[textContentOffset] === "\n") {
+                advanceWidth = 0;
+            } else {
+                advanceWidth = glyph.advanceWidth * scalingFactor;
+            }
+            if (this.offsetX + advanceWidth > this.maxWidth) {
+                if (!this.lineEmpty) {
+                    if (lastBreakOpportunityTextContentOffset > 0) {
+                        this.offsetX = lastBreakOpportunityOffsetX;
+                        this.addTextElement(
+                            textContent.substring(textContentStart, lastBreakOpportunityTextContentOffset)
+                        );
+                        textContentStart = lastBreakOpportunityTextContentOffset;
                     }
-                }
-                textContentOffset += glyph.codePoints.length;
-                offsetX += advanceWidth;
-                if (textContentOffset == lineBreak?.position) {
-                    lineEmpty = false;
-                    lastBreakOpportunity = i;
-                    lastBreakOpportunityTextContentOffset = textContentOffset;
-                    lastBreakOpportunityOffsetX = offsetX;
-                    if (lineBreak.required) {
-                        addTextElement(textContent.substring(textContentStart, i + 1), styles, fontFamily);
-                        textContentStart = i + 1;
-                        doBreak();
-                    }
-                    lineBreak = lineBreaker.nextBreak();
+                    this.doBreak();
+                    i = lastBreakOpportunity;
+                    textContentOffset = lastBreakOpportunityTextContentOffset;
+                    continue;
+                } else if (i > 0) {
+                    this.addTextElement(textContent.substring(textContentStart, i));
+                    this.doBreak();
+                    textContentStart = i;
                 }
             }
-            addTextElement(textContent.substring(textContentStart, textContent.length), styles, fontFamily);
-            if (lineBreak && lineBreak.required) {
-                doBreak();
+            textContentOffset += glyph.codePoints.length;
+            this.offsetX += advanceWidth;
+            if (textContentOffset == lineBreak?.position) {
+                this.lineEmpty = false;
+                lastBreakOpportunity = i;
+                lastBreakOpportunityTextContentOffset = textContentOffset;
+                lastBreakOpportunityOffsetX = this.offsetX;
+                if (lineBreak.required) {
+                    this.addTextElement(textContent.substring(textContentStart, i + 1));
+                    textContentStart = i + 1;
+                    this.doBreak();
+                }
+                lineBreak = lineBreaker.nextBreak();
             }
         }
-        doBreak();
+        this.addTextElement(textContent.substring(textContentStart, textContent.length));
+        if (lineBreak != null && lineBreak.required) {
+            this.doBreak();
+        }
+    }
+
+    /**
+     * Insert a line break
+     */
+    private doBreak() {
+        this.offsetX = 0;
+        this.offsetY += this.currentAscent;
+        for (const elementToAdd of this.currentTextElements) {
+            elementToAdd.y = this.offsetY;
+            this.elements.push(elementToAdd);
+        }
+        this.currentTextElements = [];
+        this.offsetY += this.currentDescent;
+        this.lineEmpty = true;
+        this.currentAscent = 0;
+        this.currentDescent = 0;
+        this.textOffset = 0;
+    }
+
+    /**
+     * Adds a new text element to the current line
+     * Uses the font and styles from the {@link currentTextContext}
+     *
+     * @param text the text to add
+     * @param width the width of the text element
+     */
+    private addTextElement(text: string) {
+        const { styles, fontFamily } = this.currentTextContext!;
+        this.usedWidth = Math.max(this.usedWidth, this.offsetX);
+        this.currentAscent = Math.max(this.currentAscent, this.fontAscent);
+        this.currentDescent = Math.max(this.currentDescent, this.fontDescent);
+        const width = this.offsetX - this.textOffset;
+        this.currentTextElements.push({
+            type: Text.TYPE,
+            text,
+            ...extractFillStyleAttributes(styles),
+            fontFamily,
+            fontSize: styles.fontSize,
+            underline: width > 0 ? this.extractUnderline() : undefined,
+            strikethrough: width > 0 ? this.extractStrikethrough() : undefined,
+            id: "",
+            x: this.textOffset,
+            y: this.offsetY,
+            width,
+            height: 0,
+            children: [],
+            edits: {}
+        });
+        this.lineEmpty = false;
+        this.textOffset = this.offsetX;
+    }
+
+    /**
+     * Extracts the underline from the current text context
+     *
+     * @returns the underline or undefined if no underline is present
+     */
+    private extractUnderline(): TextLine | undefined {
+        const font = this.currentTextContext!.font;
+        return this.extractLine("underline", font.underlinePosition, font.underlineThickness);
+    }
+
+    /**
+     * Extracts the strikethrough from the current text context
+     *
+     * @returns the strikethrough or undefined if no strikethrough is present
+     */
+    private extractStrikethrough(): TextLine | undefined {
+        const font = this.currentTextContext!.font;
+        return this.extractLine("strikethrough", font["OS/2"].yStrikeoutPosition, font["OS/2"].yStrikeoutSize);
+    }
+
+    /**
+     * Extracts a line (underline or strikethrough) from the current text context
+     *
+     * @param styleName the name of the style
+     * @param fontPos the position of the line in the font
+     * @param fontThickness the thickness of the line in the font
+     * @returns the line or undefined if the line is not present
+     */
+    private extractLine(styleName: string, fontPos: number, fontThickness: number): TextLine | undefined {
+        const { styles, scalingFactor } = this.currentTextContext!;
+        const line: string | boolean = styles[styleName];
+        if (line == undefined || line === false) {
+            return undefined;
+        }
+        const color = line === true ? styles.fill : line;
+        const lineWidth = styles[styleName + "Width"] ?? fontThickness * scalingFactor;
         return {
-            elements: elements,
-            size: {
-                width: usedMaxWidth,
-                height: offsetY
-            }
+            color,
+            width: lineWidth,
+            y: -fontPos * scalingFactor + lineWidth / 2,
+            opacity: styles[styleName + "Opacity"] ?? 1,
+            dash: styles[styleName + "Dash"],
+            dashSpace: styles[styleName + "DashSpace"]
         };
     }
 }


### PR DESCRIPTION
## new features
- underline & strikethrough styles
  - including dash, opacity, color, thickness

## bugfixes
- ensure miter limit >= 1 (otherwise pdf breaks in Acrobat reader)

## issues 
- closes #82 

## future work
- maybe add gaps  in underline where the underline intersects the glyph (similar like in browsers)
  - could be easily done via canvaskit (skia in browser), however 10mb WASM
  - maybe that part could be ripped out of skia , however lots of work and not sure if it is worth