### PR TITLE
fix scope naming conflict

### DIFF
--- a/packages/diagram/src/module/diagrams/content/uml/classifier/classifier.ts
+++ b/packages/diagram/src/module/diagrams/content/uml/classifier/classifier.ts
@@ -37,7 +37,7 @@ export const classifierModule = InterpreterModule.create(
                             )
                             contentHandlers.forEach {
                                 it[0](
-                                    scope = result,
+                                    callScope = result,
                                     args = classifierArgs,
                                     element = classifierElement,
                                     contents = classifierContents,
@@ -56,7 +56,7 @@ export const classifierModule = InterpreterModule.create(
 
                             contentHandlers.forEach {
                                 it[1](
-                                    scope = result,
+                                    callScope = result,
                                     args = classifierArgs,
                                     element = classifierElement,
                                     contents = classifierContents,

--- a/packages/diagram/src/module/diagrams/content/uml/classifier/content.ts
+++ b/packages/diagram/src/module/diagrams/content/uml/classifier/content.ts
@@ -12,10 +12,10 @@ export const contentModule = InterpreterModule.create(
             `
                 scope.internal.contentContentHandler = [
                     {
-                        args.scope.contents = list()
+                        args.callScope.contents = list()
                     },
                     {
-                        this.innerContents = args.scope.contents
+                        this.innerContents = args.callScope.contents
                         this.contents = args.contents
                         if (innerContents.length > 0) {
                             this.innerCanvasClass = list()

--- a/packages/diagram/src/module/diagrams/content/uml/classifier/entries.ts
+++ b/packages/diagram/src/module/diagrams/content/uml/classifier/entries.ts
@@ -77,7 +77,7 @@ export const entriesModule = InterpreterModule.create(
             `
                 scope.internal.entriesContentHandler = [
                     {
-                        args.scope.entries = _literalsScopeGenerator(args.scope.section)
+                        args.callScope.entries = _literalsScopeGenerator(args.callScope.section)
                     },
                     { }
                 ]

--- a/packages/diagram/src/module/diagrams/content/uml/classifier/ports.ts
+++ b/packages/diagram/src/module/diagrams/content/uml/classifier/ports.ts
@@ -19,13 +19,13 @@ export const portsModule = InterpreterModule.create(
                         value: fun([
                             ...parse(
                                 `
-                                    this.scope = args.scope
+                                    this.callScope = args.callScope
                                     this.canvasScope = args.canvasScope
                                     this.element = args.element
-                                    scope.ports = list()
+                                    callScope.ports = list()
                                 `
                             ),
-                            id("scope").assignField(
+                            id("callScope").assignField(
                                 "port",
                                 fun(
                                     `
@@ -73,7 +73,7 @@ export const portsModule = InterpreterModule.create(
                             ),
                             ...parse(
                                 `
-                                    args.element.port = scope.port
+                                    args.element.port = callScope.port
                                 `
                             )
                         ])

--- a/packages/diagram/src/module/diagrams/content/uml/classifier/ports.ts
+++ b/packages/diagram/src/module/diagrams/content/uml/classifier/ports.ts
@@ -39,7 +39,7 @@ export const portsModule = InterpreterModule.create(
                                         
                                         result = []
                                         scope.internal.providesRequiresContentHandler[0](
-                                            scope = result,
+                                            callScope = result,
                                             args = args,
                                             element = portElement,
                                             canvasScope = canvasScope

--- a/packages/diagram/src/module/diagrams/content/uml/classifier/propertiesAndMethods.ts
+++ b/packages/diagram/src/module/diagrams/content/uml/classifier/propertiesAndMethods.ts
@@ -95,12 +95,12 @@ export const propertiesAndMethodsModule = InterpreterModule.create(
             `
                 scope.internal.propertiesAndMethodsContentHandler = [
                     {
-                        this.scope = args.scope
-                        scope.public = _classifierEntryScopeGenerator("+ ", scope.section)
-                        scope.protected = _classifierEntryScopeGenerator("# ", scope.section)
-                        scope.private = _classifierEntryScopeGenerator("- ", scope.section)
-                        scope.package = _classifierEntryScopeGenerator("~ ", scope.section)
-                        scope.default = _classifierEntryScopeGenerator("", scope.section)
+                        this.callScope = args.callScope
+                        callScope.public = _classifierEntryScopeGenerator("+ ", callScope.section)
+                        callScope.protected = _classifierEntryScopeGenerator("# ", callScope.section)
+                        callScope.private = _classifierEntryScopeGenerator("- ", callScope.section)
+                        callScope.package = _classifierEntryScopeGenerator("~ ", callScope.section)
+                        callScope.default = _classifierEntryScopeGenerator("", callScope.section)
                     },
                     { }
                 ]

--- a/packages/diagram/src/module/diagrams/content/uml/classifier/providesAndRequires.ts
+++ b/packages/diagram/src/module/diagrams/content/uml/classifier/providesAndRequires.ts
@@ -20,13 +20,13 @@ export const providesAndRequiresModule = InterpreterModule.create(
                         value: fun([
                             ...parse(
                                 `
-                                    this.scope = args.scope
+                                    this.callScope = args.callScope
                                     this.canvasScope = args.canvasScope
                                     this.element = args.element
-                                    scope.ports = list()
+                                    callScope.ports = list()
                                 `
                             ),
-                            id("scope").assignField(
+                            id("callScope").assignField(
                                 "provides",
                                 fun(
                                     `
@@ -83,7 +83,7 @@ export const providesAndRequiresModule = InterpreterModule.create(
                                     }
                                 )
                             ),
-                            id("scope").assignField(
+                            id("callScope").assignField(
                                 "requires",
                                 fun(
                                     `
@@ -136,8 +136,8 @@ export const providesAndRequiresModule = InterpreterModule.create(
                             ),
                             ...parse(
                                 `
-                                    args.element.provides = scope.provides
-                                    args.element.requires = scope.requires
+                                    args.element.provides = callScope.provides
+                                    args.element.requires = callScope.requires
                                 `
                             )
                         ])

--- a/packages/diagram/src/module/diagrams/content/uml/classifier/sections.ts
+++ b/packages/diagram/src/module/diagrams/content/uml/classifier/sections.ts
@@ -12,28 +12,28 @@ export const sectionsModule = InterpreterModule.create(
             `
                 scope.internal.sectionsContentHandler = [
                     {
-                        this.scope = args.scope
-                        scope.sections = list()
-                        scope.section = listWrapper {
+                        this.callScope = args.callScope
+                        callScope.sections = list()
+                        callScope.section = listWrapper {
                             sectionIndex = args.section
                             newSection = it
                             if(sectionIndex == null) {
-                                scope.sections += newSection
+                                callScope.sections += newSection
                             } {
-                                while { scope.sections.length <= sectionIndex } {
-                                    scope.sections += null
+                                while { callScope.sections.length <= sectionIndex } {
+                                    callScope.sections += null
                                 }
-                                if(scope.sections.get(sectionIndex) == null) {
-                                    scope.sections.set(sectionIndex, list())
+                                if(callScope.sections.get(sectionIndex) == null) {
+                                    callScope.sections.set(sectionIndex, list())
                                 }
-                                scope.sections.get(sectionIndex).addAll(newSection)
+                                callScope.sections.get(sectionIndex).addAll(newSection)
                             }
                         }
                     },
                     {
                         this.contents = args.contents
 
-                        args.scope.sections.forEach {
+                        args.callScope.sections.forEach {
                             this.section = it
                             if (section != null) {
                                 contents += path(path = "M 0 0 L 1 0", class = list("separator"))


### PR DESCRIPTION
The identifier `scope` was misused in the context of classifier content handlers, as it should sometimes refer to the global scope and sometimes the scope for the callback function.
This caused weird behavior and failures, e.g.
```
componentDiagram {
    component("Test") 

    Test.requires("lol")
}
```
failed while 
```
componentDiagram {
    component("Test") { }

    Test.requires("lol")
}
```
worked.

To fix this problem overall, I choose a different name everywhere for the scope provided to the callback