### PR TITLE
Improve component diagram

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,8 +5,7 @@ import * as path from "path";
 import { program } from "commander";
 import { PDFRenderer } from "@hylimo/diagram-render-pdf";
 import { SVGRenderer } from "@hylimo/diagram-render-svg";
-import { DiagramEngine, LayoutEngine, defaultDiagramModules } from "@hylimo/diagram";
-import { Interpreter, Parser, defaultModules } from "@hylimo/core";
+import { DiagramEngine } from "@hylimo/diagram";
 import { DiagramConfig } from "@hylimo/diagram-common";
 
 program
@@ -56,12 +55,7 @@ try {
     process.exit(1);
 }
 
-const layoutEngine = new LayoutEngine();
-const diagramEngine = new DiagramEngine(
-    new Parser(false),
-    new Interpreter(defaultDiagramModules, defaultModules, maxExecutionSteps),
-    layoutEngine
-);
+const diagramEngine = new DiagramEngine([], maxExecutionSteps);
 
 const config: DiagramConfig = {
     theme: darkMode ? "dark" : "light",

--- a/packages/core/src/stdlib/modules/booleanModule.ts
+++ b/packages/core/src/stdlib/modules/booleanModule.ts
@@ -102,7 +102,7 @@ export const booleanModule = InterpreterModule.create(
                         );
                     },
                     {
-                        docs: "Performs logical and (&&). NO short circuit evaluation! The first argument is always evaluated",
+                        docs: "Performs logical and (&&) WITHOUT short circuit evaluation! The second argument is always evaluated",
                         params: [
                             [SemanticFieldNames.SELF, "the left side of the logical and", booleanType],
                             [0, "the right side of the logical and", booleanType]
@@ -121,7 +121,7 @@ export const booleanModule = InterpreterModule.create(
                         );
                     },
                     {
-                        docs: "Performs logical or (||). NO short circuit evaluation! The first argument is always evaluated",
+                        docs: "Performs logical or (||) WITHOUT short circuit evaluation! The second argument is always evaluated",
                         params: [
                             [SemanticFieldNames.SELF, "the left side of the logical or", booleanType],
                             [0, "the right side of the logical or", booleanType]

--- a/packages/core/src/stdlib/modules/booleanModule.ts
+++ b/packages/core/src/stdlib/modules/booleanModule.ts
@@ -93,6 +93,44 @@ export const booleanModule = InterpreterModule.create(
                 )
             ),
             id(booleanProto).assignField(
+                "&",
+                jsFun(
+                    (args, context) => {
+                        return context.newBoolean(
+                            assertBoolean(args.getFieldValue(SemanticFieldNames.SELF, context)) &&
+                                assertBoolean(args.getFieldValue(0, context))
+                        );
+                    },
+                    {
+                        docs: "Performs logical and (&&). NO short circuit evaluation! The first argument is always evaluated",
+                        params: [
+                            [SemanticFieldNames.SELF, "the left side of the logical and", booleanType],
+                            [0, "the right side of the logical and", booleanType]
+                        ],
+                        returns: "The result of the logical and"
+                    }
+                )
+            ),
+            id(booleanProto).assignField(
+                "|",
+                jsFun(
+                    (args, context) => {
+                        return context.newBoolean(
+                            assertBoolean(args.getFieldValue(SemanticFieldNames.SELF, context)) ||
+                                assertBoolean(args.getFieldValue(0, context))
+                        );
+                    },
+                    {
+                        docs: "Performs logical or (||). NO short circuit evaluation! The first argument is always evaluated",
+                        params: [
+                            [SemanticFieldNames.SELF, "the left side of the logical or", booleanType],
+                            [0, "the right side of the logical or", booleanType]
+                        ],
+                        returns: "The result of the logical or"
+                    }
+                )
+            ),
+            id(booleanProto).assignField(
                 "<",
                 jsFun(
                     (args, context) => {

--- a/packages/core/src/stdlib/modules/operatorModule.ts
+++ b/packages/core/src/stdlib/modules/operatorModule.ts
@@ -15,7 +15,7 @@ export const operatorModule = InterpreterModule.create(
     [],
     [DefaultModuleNames.COMMON],
     [
-        ...["*", "/", "%", "&&", "||", ">", ">=", "<", "<=", ">>", "<<", "+="].map((operator) =>
+        ...["*", "/", "%", "&&", "||", "&", "|", ">", ">=", "<", "<=", ">>", "<<", "+="].map((operator) =>
             id(SemanticFieldNames.THIS).assignField(
                 operator,
                 native(
@@ -158,7 +158,9 @@ export const operatorModule = InterpreterModule.create(
             "-",
             native(
                 (args, context) => {
-                    args.shift();
+                    if (args.length == 3 && args[0].name === SemanticFieldNames.SELF) {
+                        args.shift();
+                    }
                     if (
                         args.length > 2 ||
                         args.length < 1 ||

--- a/packages/core/src/stdlib/modules/operatorModule.ts
+++ b/packages/core/src/stdlib/modules/operatorModule.ts
@@ -20,7 +20,9 @@ export const operatorModule = InterpreterModule.create(
                 operator,
                 native(
                     (args, context) => {
-                        args.shift();
+                        if (args.length == 3 && args[0].name === SemanticFieldNames.SELF) {
+                            args.shift();
+                        }
                         if (args.length != 2 || args[0].name !== undefined || args[1].name !== undefined) {
                             throw new RuntimeError(`Expected exactly two positional arguments for ${operator}`);
                         }
@@ -133,7 +135,9 @@ export const operatorModule = InterpreterModule.create(
             "??",
             native(
                 (args, context) => {
-                    args.shift();
+                    if (args.length == 3 && args[0].name === SemanticFieldNames.SELF) {
+                        args.shift();
+                    }
                     if (args.length != 2 || args[0].name !== undefined || args[1].name !== undefined) {
                         throw new RuntimeError(`Expected exactly two positional arguments for ??}`);
                     }

--- a/packages/core/src/stdlib/typeHelpers.ts
+++ b/packages/core/src/stdlib/typeHelpers.ts
@@ -124,6 +124,16 @@ export function assertObject(value: BaseObject, description = ""): asserts value
 }
 
 /**
+ * Checks if a value is a FullObject
+ *
+ * @param value the value to check
+ * @returns true iff it is a FullObject
+ */
+export function isObject(value: BaseObject): value is FullObject {
+    return value instanceof FullObject;
+}
+
+/**
  * Helper to check that an object is a WrapperObject, throws an error if not
  *
  * @param value the value to check

--- a/packages/diagram-ui/src/di.config.ts
+++ b/packages/diagram-ui/src/di.config.ts
@@ -98,7 +98,9 @@ const diagramModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     configureModelElement(context, CanvasConnection.TYPE, SCanvasConnection, CanvasConnectionView, {
         enable: [selectFeature, moveFeature]
     });
-    configureModelElement(context, Marker.TYPE, SMarker, MarkerView);
+    configureModelElement(context, Marker.TYPE, SMarker, MarkerView, {
+        enable: [selectFeature, moveFeature]
+    });
     registerModelElement(context, CanvasLineSegment.TYPE, SCanvasLineSegment);
     registerModelElement(context, CanvasBezierSegment.TYPE, SCanvasBezierSegment);
     registerModelElement(context, CanvasAxisAlignedSegment.TYPE, SCanvasAxisAlignedSegment);

--- a/packages/diagram-ui/src/features/move/moveMouseListener.ts
+++ b/packages/diagram-ui/src/features/move/moveMouseListener.ts
@@ -37,6 +37,7 @@ import { SCanvasAxisAlignedSegment } from "../../model/canvas/sCanvasAxisAligned
 import { AxisAligedSegmentEditHandler } from "./axisAlignedSegmentEditHandler.js";
 import { Matrix, compose, translate, applyToPoint, inverse, decomposeTSR, scale, rotate } from "transformation-matrix";
 import { MovedElementsSelector } from "./movedElementsSelector.js";
+import { SMarker } from "../../model/canvas/sMarker.js";
 
 /**
  * The maximum number of updates that can be performed on the same revision.
@@ -404,8 +405,9 @@ export class MoveMouseListener extends MouseListener {
      */
     private createMoveHandler(target: SModelElementImpl, event: MouseEvent): MoveHandler | null {
         const selected = this.getSelectedElements(target.root).filter(
-            (element) => element instanceof SCanvasPoint || element instanceof SCanvasElement
-        ) as (SCanvasPoint | SCanvasElement)[];
+            (element) =>
+                element instanceof SCanvasPoint || element instanceof SCanvasElement || element instanceof SMarker
+        ) as (SCanvasPoint | SCanvasElement | SMarker)[];
         if (selected.length === 0) {
             return null;
         }

--- a/packages/diagram-ui/src/features/move/movedElementsSelector.ts
+++ b/packages/diagram-ui/src/features/move/movedElementsSelector.ts
@@ -43,7 +43,7 @@ export class MovedElementsSelector {
      * @param index index for element lookup
      */
     constructor(
-        selected: (SCanvasElement | SCanvasPoint)[],
+        selected: (SCanvasElement | SCanvasPoint | SMarker)[],
         private readonly index: IModelIndex
     ) {
         this.registerElements(new Set(selected));
@@ -56,13 +56,15 @@ export class MovedElementsSelector {
      *
      * @param points the points to move
      */
-    private registerElements(elements: Set<SCanvasPoint | SCanvasElement>) {
-        let currentElements: Set<SCanvasContent> = elements;
+    private registerElements(elements: Set<SCanvasPoint | SCanvasElement | SMarker>) {
+        let currentElements: Set<SCanvasContent | SMarker> = elements;
         while (currentElements.size > 0) {
             const newElements = new Set<SCanvasContent>();
             for (const element of currentElements) {
                 if (element instanceof SCanvasConnection) {
                     newElements.add(this.index.getById(element.segments.at(-1)!.end) as SCanvasContent);
+                } else if (element instanceof SMarker) {
+                    newElements.add(this.index.getById(element.posId) as SCanvasContent);
                 } else {
                     this.movedElements.add(element as SCanvasPoint | SCanvasElement);
                 }

--- a/packages/diagram-ui/src/model/canvas/sMarker.ts
+++ b/packages/diagram-ui/src/model/canvas/sMarker.ts
@@ -1,11 +1,24 @@
 import { Marker } from "@hylimo/diagram-common";
 import { SElement } from "../sElement.js";
+import { Selectable } from "sprotty-protocol";
+import { SCanvasConnection } from "./sCanvasConnection.js";
 
 /**
  * Model for Marker
  */
-export class SMarker extends SElement implements Marker {
+export class SMarker extends SElement implements Marker, Selectable {
     override type!: typeof Marker.TYPE;
+    override parent!: SCanvasConnection;
+    private _selected = false;
+
+    get selected(): boolean {
+        return this._selected;
+    }
+
+    set selected(value: boolean) {
+        this._selected = value;
+        this.parent.parent.pointVisibilityManager.setSelectionState(this, value);
+    }
     /**
      * The width of the element
      */
@@ -30,4 +43,18 @@ export class SMarker extends SElement implements Marker {
      * The y coordinate of the reference point
      */
     refY!: number;
+
+    /**
+     * The id of the start/end (depending on pos) of the parent connection
+     */
+    get posId(): string {
+        return this.pos === "start" ? this.parent.start : this.parent.segments.at(-1)!.end;
+    }
+
+    /**
+     * List of dependencies of this Marker
+     */
+    get dependencies(): string[] {
+        return [this.posId];
+    }
 }

--- a/packages/diagram-ui/src/model/sRoot.ts
+++ b/packages/diagram-ui/src/model/sRoot.ts
@@ -87,108 +87,106 @@ export class SRoot extends ViewportRootElementImpl {
      */
     generateStyle(baseDiv: string): string {
         const staticStyles = `
-        text {
-            white-space: pre;
-        }
-        
-        .canvas-element {
-            pointer-events: visible;
-        }
-        
         #${baseDiv}.sprotty svg {
+
             --diagram-zoom: ${this.zoom};
             --diagram-zoom-normalized: ${this.zoom / Math.pow(2, Math.round(Math.log2(this.zoom) / 2) * 2)};
             --diagram-scroll-x: ${this.scroll.x}px;
             --diagram-scroll-y: ${this.scroll.y}px;
             background:
-              conic-gradient(from 90deg at 1px 1px, var(--diagram-background) 90deg, var(--diagram-grid) 0) 
-              calc(var(--diagram-scroll-x) * -1 * var(--diagram-zoom))
-              calc(var(--diagram-scroll-y) * -1 * var(--diagram-zoom)) /
-              calc(100px * var(--diagram-zoom-normalized)) calc(100px * var(--diagram-zoom-normalized));
-        }
+            conic-gradient(from 90deg at 1px 1px, var(--diagram-background) 90deg, var(--diagram-grid) 0) 
+            calc(var(--diagram-scroll-x) * -1 * var(--diagram-zoom))
+            calc(var(--diagram-scroll-y) * -1 * var(--diagram-zoom)) /
+            calc(100px * var(--diagram-zoom-normalized)) calc(100px * var(--diagram-zoom-normalized));
 
-        .sprotty svg text {
-            user-select: none;
-        }
+            text {
+                white-space: pre;
+                user-select: none;
+            }
+            
+            .canvas-element,.marker {
+                pointer-events: visible;
+            }
+    
+            .selected-rect {
+                fill: var(--diagram-layout-color-overlay);
+                stroke: var(--diagram-layout-color-selected);
+                stroke-width: calc(5px / var(--diagram-zoom));
+                stroke-dasharray: calc(16px / var(--diagram-zoom));
+            }
+            
+            .canvas-point {
+                stroke-linecap: round;
+                stroke-width: calc(${SRoot.POINT_SIZE}px / var(--diagram-zoom));
+                stroke: var(--diagram-layout-color);
+            }
+            
+            .canvas-point.selected {
+                stroke: var(--diagram-layout-color-selected);
+            }
+            
+            .canvas-dependency-line {
+                stroke: var(--diagram-layout-color);
+                stroke-width: calc(2px / var(--diagram-zoom));
+                stroke-dasharray: calc(16px / var(--diagram-zoom));
+                fill: none;
+                pointer-events: none;
+            }
+            
+            .bezier-handle-line {
+                stroke: var(--diagram-layout-color);
+                stroke-width: calc(4px / var(--diagram-zoom));
+                fill: none;
+                pointer-events: none;
+            }
+            
+            .select-canvas-connection {
+                stroke-width: calc(12px / var(--diagram-zoom));
+                fill: none;
+                stroke: transparent;
+                pointer-events: visibleStroke;
+            }
 
-        .selected-rect {
-            fill: var(--diagram-layout-color-overlay);
-            stroke: var(--diagram-layout-color-selected);
-            stroke-width: calc(5px / var(--diagram-zoom));
-            stroke-dasharray: calc(16px / var(--diagram-zoom));
-        }
-        
-        .canvas-point {
-            stroke-linecap: round;
-            stroke-width: calc(${SRoot.POINT_SIZE}px / var(--diagram-zoom));
-            stroke: var(--diagram-layout-color);
-        }
-        
-        .canvas-point.selected {
-            stroke: var(--diagram-layout-color-selected);
-        }
-        
-        .canvas-dependency-line {
-            stroke: var(--diagram-layout-color);
-            stroke-width: calc(2px / var(--diagram-zoom));
-            stroke-dasharray: calc(16px / var(--diagram-zoom));
-            fill: none;
-            pointer-events: none;
-        }
-        
-        .bezier-handle-line {
-            stroke: var(--diagram-layout-color);
-            stroke-width: calc(4px / var(--diagram-zoom));
-            fill: none;
-            pointer-events: none;
-        }
-        
-        .select-canvas-connection {
-            stroke-width: calc(12px / var(--diagram-zoom));
-            fill: none;
-            stroke: transparent;
-            pointer-events: visibleStroke;
-        }
+            .canvas-rotate-icon>path {
+                fill: var(--diagram-layout-color);
+            }
 
-        .canvas-rotate-icon>path {
-            fill: var(--diagram-layout-color);
-        }
+            .canvas-rotate-icon>rect {
+                fill: transparent;
+                cursor: pointer;
+            }
 
-        .canvas-rotate-icon>rect {
-            fill: transparent;
-            cursor: pointer;
-        }
+            .resize {
+                stroke-width: calc(12px / var(--diagram-zoom));
+                stroke: transparent;
+            }
 
-        .resize {
-            stroke-width: calc(12px / var(--diagram-zoom));
-            stroke: transparent;
-        }
+            .resize-corner {
+                stroke-linecap: square;
+            }
 
-        .resize-corner {
-            stroke-linecap: square;
-        }
+            .resize-cursor-0, .resize-cursor-4 {
+                cursor: nwse-resize;
+            }
 
-        .resize-cursor-0, .resize-cursor-4 {
-            cursor: nwse-resize;
-        }
+            .resize-cursor-1, .resize-cursor-5 {
+                cursor: ns-resize;
+            }
 
-        .resize-cursor-1, .resize-cursor-5 {
-            cursor: ns-resize;
-        }
+            .resize-cursor-2, .resize-cursor-6 {
+                cursor: nesw-resize;
+            }
 
-        .resize-cursor-2, .resize-cursor-6 {
-            cursor: nesw-resize;
-        }
+            .resize-cursor-3, .resize-cursor-7 {
+                cursor: ew-resize;
+            }
 
-        .resize-cursor-3, .resize-cursor-7 {
-            cursor: ew-resize;
-        }
-
-        .${SCanvasAxisAlignedSegment.SEGMENT_EDIT_CLASS_X} {
-            cursor: ns-resize;
-        }
-        .${SCanvasAxisAlignedSegment.SEGMENT_EDIT_CLASS_Y} {
-            cursor: ew-resize;
+            .${SCanvasAxisAlignedSegment.SEGMENT_EDIT_CLASS_X} {
+                cursor: ns-resize;
+            }
+            .${SCanvasAxisAlignedSegment.SEGMENT_EDIT_CLASS_Y} {
+                cursor: ew-resize;
+            }
         }
         `;
         return convertFontsToCssStyle(this.fonts) + staticStyles;

--- a/packages/diagram-ui/src/views/canvas/markerView.ts
+++ b/packages/diagram-ui/src/views/canvas/markerView.ts
@@ -1,6 +1,6 @@
 import { injectable } from "inversify";
 import { VNode } from "snabbdom";
-import { IView, IViewArgs, RenderingContext } from "sprotty";
+import { IView, IViewArgs, RenderingContext, svg } from "sprotty";
 import { SMarker } from "../../model/canvas/sMarker.js";
 
 /**
@@ -9,6 +9,14 @@ import { SMarker } from "../../model/canvas/sMarker.js";
 @injectable()
 export class MarkerView implements IView {
     render(model: Readonly<SMarker>, context: RenderingContext, _args?: IViewArgs | undefined): VNode | undefined {
-        return context.renderChildren(model)[0];
+        return svg(
+            "g",
+            {
+                class: {
+                    marker: true
+                }
+            },
+            ...context.renderChildren(model)
+        );
     }
 }

--- a/packages/diagram/src/layout/elements/attributes.ts
+++ b/packages/diagram/src/layout/elements/attributes.ts
@@ -1,7 +1,18 @@
 import { enumType, numberType, stringType } from "@hylimo/core";
 import { FilledElement, StrokedElement } from "@hylimo/diagram-common";
-import { HorizontalAlignment, VerticalAlignment } from "../layoutElement.js";
+import { HorizontalAlignment, VerticalAlignment, Visibility } from "../layoutElement.js";
 import { LineCap, LineJoin } from "@hylimo/diagram-common";
+
+/**
+ * Visibility style attributes
+ */
+export const visibilityStyleAttributes = [
+    {
+        name: "visibility",
+        description: 'optional visibility of the element, must be one of "visible", "hidden" or "collapse"',
+        type: enumType(Visibility)
+    }
+];
 
 /**
  * Style attributes related to size
@@ -43,6 +54,7 @@ export const alignStyleAttributes = [
  * Default style attributes, including margin, alignment, and size attributes
  */
 export const defaultStyleAttributes = [
+    ...visibilityStyleAttributes,
     ...sizeStyleAttributes,
     ...alignStyleAttributes,
     { name: "marginTop", description: "optional top margin of the element, must be a number", type: numberType },

--- a/packages/diagram/src/layout/elements/canvas/absolutePointLayoutConfig.ts
+++ b/packages/diagram/src/layout/elements/canvas/absolutePointLayoutConfig.ts
@@ -12,6 +12,7 @@ export class AbsolutePointLayoutConfig extends CanvasPointLayoutConfig {
 
     constructor() {
         super(
+            [],
             [
                 {
                     name: "x",
@@ -23,8 +24,7 @@ export class AbsolutePointLayoutConfig extends CanvasPointLayoutConfig {
                     description: "the y coordinate",
                     type: numberType
                 }
-            ],
-            []
+            ]
         );
     }
 
@@ -34,8 +34,8 @@ export class AbsolutePointLayoutConfig extends CanvasPointLayoutConfig {
         const result: AbsolutePoint = {
             type: AbsolutePoint.TYPE,
             id,
-            x: xValue?.value?.toNative(),
-            y: yValue?.value.toNative(),
+            x: xValue?.value?.toNative() ?? 0,
+            y: yValue?.value?.toNative() ?? 0,
             children: [],
             edits: element.edits
         };

--- a/packages/diagram/src/layout/elements/canvas/canvasConnectionLayoutConfig.ts
+++ b/packages/diagram/src/layout/elements/canvas/canvasConnectionLayoutConfig.ts
@@ -98,7 +98,7 @@ export class CanvasConnectionLayoutConfig extends EditableCanvasContentLayoutCon
         return [result];
     }
 
-    override getChildren(layout: Layout, element: LayoutElement): FullObject[] {
+    override getChildren(element: LayoutElement): FullObject[] {
         const children: FullObject[] = [];
         const contents = element.element.getLocalFieldOrUndefined("contents")?.value as FullObject | undefined;
         if (contents) {

--- a/packages/diagram/src/layout/elements/canvas/canvasConnectionLayoutConfig.ts
+++ b/packages/diagram/src/layout/elements/canvas/canvasConnectionLayoutConfig.ts
@@ -63,7 +63,6 @@ export class CanvasConnectionLayoutConfig extends EditableCanvasContentLayoutCon
     }
 
     override measure(layout: Layout, element: LayoutElement, constraints: SizeConstraints): Size {
-        // TODO (maybe) better size calculation
         for (const content of element.children) {
             layout.measure(content, constraints);
         }
@@ -79,7 +78,7 @@ export class CanvasConnectionLayoutConfig extends EditableCanvasContentLayoutCon
             children: contents
                 .filter((content) => content.layoutConfig.type != Marker.TYPE)
                 .flatMap((content) => layout.layout(content, position, content.measuredSize!)),
-            ...extractStrokeStyleAttributes(element.styles),
+            ...(element.isHidden ? {} : extractStrokeStyleAttributes(element.styles)),
             edits: element.edits
         };
         const contentLookup = new Map(contents.map((content) => [content.element, content]));

--- a/packages/diagram/src/layout/elements/canvas/canvasElementLayoutConfig.ts
+++ b/packages/diagram/src/layout/elements/canvas/canvasElementLayoutConfig.ts
@@ -9,7 +9,7 @@ import {
     VerticalAlignment
 } from "../../layoutElement.js";
 import { Layout } from "../../engine/layout.js";
-import { alignStyleAttributes, sizeStyleAttributes } from "../attributes.js";
+import { alignStyleAttributes, sizeStyleAttributes, visibilityStyleAttributes } from "../attributes.js";
 import { EditableCanvasContentLayoutConfig } from "./editableCanvasContentLayoutConfig.js";
 
 /**
@@ -42,7 +42,8 @@ export class CanvasElementLayoutConfig extends EditableCanvasContentLayoutConfig
                     description: "the rotation in degrees",
                     type: numberType
                 },
-                ...sizeStyleAttributes
+                ...sizeStyleAttributes,
+                ...visibilityStyleAttributes
             ]
         );
     }

--- a/packages/diagram/src/layout/elements/canvas/canvasElementLayoutConfig.ts
+++ b/packages/diagram/src/layout/elements/canvas/canvasElementLayoutConfig.ts
@@ -85,7 +85,7 @@ export class CanvasElementLayoutConfig extends EditableCanvasContentLayoutConfig
         return [result];
     }
 
-    override getChildren(layout: Layout, element: LayoutElement): FullObject[] {
+    override getChildren(element: LayoutElement): FullObject[] {
         const content = element.element.getLocalFieldOrUndefined("content")?.value as FullObject;
         return [content];
     }
@@ -134,21 +134,5 @@ export class CanvasElementLayoutConfig extends EditableCanvasContentLayoutConfig
                 elementProto
             `
         );
-    }
-
-    override postprocessStyles(element: LayoutElement, styles: Record<string, any>): Record<string, any> {
-        const width = element.element.getLocalFieldOrUndefined("_width")?.value?.toNative();
-        if (width != undefined) {
-            styles.width = width;
-        }
-        const height = element.element.getLocalFieldOrUndefined("_height")?.value?.toNative();
-        if (height != undefined) {
-            styles.height = height;
-        }
-        const rotation = element.element.getLocalFieldOrUndefined("_rotation")?.value?.toNative();
-        if (rotation != undefined) {
-            styles.rotation = rotation;
-        }
-        return styles;
     }
 }

--- a/packages/diagram/src/layout/elements/canvas/canvasLayoutConfig.ts
+++ b/packages/diagram/src/layout/elements/canvas/canvasLayoutConfig.ts
@@ -205,7 +205,7 @@ export class CanvasLayoutConfig extends StyledElementLayoutConfig {
         );
     }
 
-    override getChildren(layout: Layout, element: LayoutElement): FullObject[] {
+    override getChildren(element: LayoutElement): FullObject[] {
         const contents = element.element.getLocalFieldOrUndefined("contents")?.value as FullObject | undefined;
         if (contents) {
             return objectToList(contents) as FullObject[];

--- a/packages/diagram/src/layout/elements/canvas/linePointLayoutConfig.ts
+++ b/packages/diagram/src/layout/elements/canvas/linePointLayoutConfig.ts
@@ -61,7 +61,7 @@ export class LinePointLayoutConfig extends CanvasPointLayoutConfig {
                     name: "distance",
                     description: "the distance of the point to the line, defaults to 0",
                     type: numberType
-                },
+                }
             ]
         );
     }

--- a/packages/diagram/src/layout/elements/canvas/linePointLayoutConfig.ts
+++ b/packages/diagram/src/layout/elements/canvas/linePointLayoutConfig.ts
@@ -7,7 +7,6 @@ import {
     isNumber,
     numberType,
     objectType,
-    optional,
     or
 } from "@hylimo/core";
 import {
@@ -47,22 +46,23 @@ export class LinePointLayoutConfig extends CanvasPointLayoutConfig {
         super(
             [
                 {
-                    name: "pos",
-                    description: "the relative offset on the line, must be between 0 and 1 (inclusive)",
-                    type: optional(LinePointLayoutConfig.POS_TYPE)
-                },
-                {
-                    name: "distance",
-                    description: "the distance of the point to the line, defaults to 0",
-                    type: optional(numberType)
-                },
-                {
                     name: "lineProvider",
                     description: "the target which provides the line",
                     type: elementType(CanvasConnection.TYPE, CanvasElement.TYPE)
                 }
             ],
-            []
+            [
+                {
+                    name: "pos",
+                    description: "the relative offset on the line, must be between 0 and 1 (inclusive)",
+                    type: LinePointLayoutConfig.POS_TYPE
+                },
+                {
+                    name: "distance",
+                    description: "the distance of the point to the line, defaults to 0",
+                    type: numberType
+                },
+            ]
         );
     }
 

--- a/packages/diagram/src/layout/elements/canvas/markerLayoutConfig.ts
+++ b/packages/diagram/src/layout/elements/canvas/markerLayoutConfig.ts
@@ -43,7 +43,6 @@ export class MarkerLayoutConfig extends StyledElementLayoutConfig {
     }
 
     override measure(layout: Layout, element: LayoutElement, constraints: SizeConstraints): Size {
-        // TODO (maybe) better size calculation
         const content = element.children[0];
         const contentElement = layout.measure(content, constraints);
         return contentElement.measuredSize!;

--- a/packages/diagram/src/layout/elements/canvas/markerLayoutConfig.ts
+++ b/packages/diagram/src/layout/elements/canvas/markerLayoutConfig.ts
@@ -67,7 +67,7 @@ export class MarkerLayoutConfig extends StyledElementLayoutConfig {
         return [result];
     }
 
-    override getChildren(layout: Layout, element: LayoutElement): FullObject[] {
+    override getChildren(element: LayoutElement): FullObject[] {
         const content = element.element.getLocalFieldOrUndefined("content")?.value as FullObject;
         return [content];
     }

--- a/packages/diagram/src/layout/elements/canvas/relativePointLayoutConfig.ts
+++ b/packages/diagram/src/layout/elements/canvas/relativePointLayoutConfig.ts
@@ -30,7 +30,7 @@ export class RelativePointLayoutConfig extends CanvasPointLayoutConfig {
                     name: "offsetY",
                     description: "the y offset",
                     type: numberType
-                },
+                }
             ]
         );
     }

--- a/packages/diagram/src/layout/elements/canvas/relativePointLayoutConfig.ts
+++ b/packages/diagram/src/layout/elements/canvas/relativePointLayoutConfig.ts
@@ -1,4 +1,4 @@
-import { ExecutableAbstractFunctionExpression, FullObject, fun, numberType, optional } from "@hylimo/core";
+import { ExecutableAbstractFunctionExpression, FullObject, fun, numberType } from "@hylimo/core";
 import { Size, Element, RelativePoint, Point, DefaultEditTypes } from "@hylimo/diagram-common";
 import { canvasContentType } from "../../../module/base/types.js";
 import { LayoutElement } from "../../layoutElement.js";
@@ -15,22 +15,23 @@ export class RelativePointLayoutConfig extends CanvasPointLayoutConfig {
         super(
             [
                 {
-                    name: "offsetX",
-                    description: "the x offset",
-                    type: optional(numberType)
-                },
-                {
-                    name: "offsetY",
-                    description: "the y offset",
-                    type: optional(numberType)
-                },
-                {
                     name: "target",
                     description: "the target point or canvas element of which the relative point is based",
                     type: canvasContentType
                 }
             ],
-            []
+            [
+                {
+                    name: "offsetX",
+                    description: "the x offset",
+                    type: numberType
+                },
+                {
+                    name: "offsetY",
+                    description: "the y offset",
+                    type: numberType
+                },
+            ]
         );
     }
 

--- a/packages/diagram/src/layout/elements/contentShapeLayoutConfig.ts
+++ b/packages/diagram/src/layout/elements/contentShapeLayoutConfig.ts
@@ -2,7 +2,6 @@ import { AttributeConfig, ContentCardinality, LayoutElement } from "../layoutEle
 import { ShapeLayoutConfig } from "./shapeLayoutConfig.js";
 import { elementType } from "../../module/base/types.js";
 import { FullObject } from "@hylimo/core";
-import { Layout } from "../engine/layout.js";
 
 /**
  * Base class for all shape layout configs with a content
@@ -21,7 +20,7 @@ export abstract class ContentShapeLayoutConfig extends ShapeLayoutConfig {
         super(additionalAttributes, additionalStyleAttributes);
     }
 
-    override getChildren(layout: Layout, element: LayoutElement): FullObject[] {
+    override getChildren(element: LayoutElement): FullObject[] {
         const content = element.element.getLocalFieldOrUndefined("content")?.value as FullObject | undefined;
         if (content != undefined) {
             return [content];

--- a/packages/diagram/src/layout/elements/elementLayoutConfig.ts
+++ b/packages/diagram/src/layout/elements/elementLayoutConfig.ts
@@ -56,11 +56,10 @@ export abstract class ElementLayoutConfig implements LayoutConfig {
     /**
      * Returns the children of the element
      *
-     * @param layout performs the layout
      * @param element the element to get the children of
      * @returns the children of the element
      */
-    abstract getChildren(layout: Layout, element: LayoutElement): FullObject[];
+    abstract getChildren(element: LayoutElement): FullObject[];
 
     /**
      * Called to determine the size the element requires
@@ -186,17 +185,6 @@ export abstract class ElementLayoutConfig implements LayoutConfig {
      */
     createPrototype(): ExecutableAbstractFunctionExpression {
         return fun("object(proto = it)");
-    }
-
-    /**
-     * Called to postprocess the extracted styles
-     *
-     * @param _element the element to postprocess
-     * @param styles the extracted styles
-     * @returns the postprocessed styles
-     */
-    postprocessStyles(_element: LayoutElement, styles: Record<string, any>): Record<string, any> {
-        return styles;
     }
 
     /**

--- a/packages/diagram/src/layout/elements/ellipseLayoutConfig.ts
+++ b/packages/diagram/src/layout/elements/ellipseLayoutConfig.ts
@@ -47,7 +47,11 @@ export class EllipseLayoutConfig extends ContentShapeLayoutConfig {
             });
             result.children.push(...layout.layout(content, contentPosition, contentSize));
         }
-        return [result];
+        if (element.isHidden) {
+            return result.children;
+        } else {
+            return [result];
+        }
     }
 
     override outline(layout: Layout, element: LayoutElement, position: Point, size: Size, id: string): Line {

--- a/packages/diagram/src/layout/elements/panelLayoutConfig.ts
+++ b/packages/diagram/src/layout/elements/panelLayoutConfig.ts
@@ -22,7 +22,7 @@ export abstract class PanelLayoutConfig extends StyledElementLayoutConfig {
         super(additionalAttributes, additionalStyleAttributes);
     }
 
-    override getChildren(layout: Layout, element: LayoutElement): FullObject[] {
+    override getChildren(element: LayoutElement): FullObject[] {
         const contents = element.element.getLocalFieldOrUndefined("contents")?.value as FullObject | undefined;
         if (contents) {
             return objectToList(contents) as FullObject[];

--- a/packages/diagram/src/layout/elements/pathLayoutConfig.ts
+++ b/packages/diagram/src/layout/elements/pathLayoutConfig.ts
@@ -73,6 +73,9 @@ export class PathLayoutConfig extends ShapeLayoutConfig {
     }
 
     override layout(layout: Layout, element: LayoutElement, position: Point, size: Size, id: string): Element[] {
+        if (element.isHidden) {
+            return [];
+        }
         const expectedSize = element.layoutedPath.size;
         const shapeProperties = element.shapeProperties;
         let layoutedPath = element.layoutedPath;

--- a/packages/diagram/src/layout/elements/rectLayoutConfig.ts
+++ b/packages/diagram/src/layout/elements/rectLayoutConfig.ts
@@ -66,7 +66,11 @@ export class RectLayoutConfig extends ContentShapeLayoutConfig {
             }
             result.children.push(...layout.layout(content, contentPosition, contentSize));
         }
-        return [result];
+        if (element.isHidden) {
+            return result.children;
+        } else {
+            return [result];
+        }
     }
 
     override outline(layout: Layout, element: LayoutElement, position: Point, size: Size, id: string): Line {

--- a/packages/diagram/src/layout/elements/textLayoutConfig.ts
+++ b/packages/diagram/src/layout/elements/textLayoutConfig.ts
@@ -38,6 +38,9 @@ export class TextLayoutConfig extends StyledElementLayoutConfig {
     }
 
     override layout(layout: Layout, element: LayoutElement, position: Point, size: Size, id: string): Element[] {
+        if (element.isHidden) {
+            return [];
+        }
         const elements = element.layoutedContents as Text[];
         for (let i = 0; i < elements.length; i++) {
             const element = elements[i];

--- a/packages/diagram/src/layout/elements/textLayoutConfig.ts
+++ b/packages/diagram/src/layout/elements/textLayoutConfig.ts
@@ -48,7 +48,7 @@ export class TextLayoutConfig extends StyledElementLayoutConfig {
         return elements;
     }
 
-    override getChildren(layout: Layout, element: LayoutElement): FullObject[] {
+    override getChildren(element: LayoutElement): FullObject[] {
         const contents = element.element.getLocalFieldOrUndefined("contents")?.value as FullObject | undefined;
         if (contents) {
             return objectToList(contents) as FullObject[];

--- a/packages/diagram/src/layout/engine/edits.ts
+++ b/packages/diagram/src/layout/engine/edits.ts
@@ -17,13 +17,13 @@ import {
     Range
 } from "@hylimo/core";
 import {
-    EditSpecification,
     TemplateEntry,
     EditSpecificationEntry,
     ReplaceEditSpecificationEntry,
     AddEditSpecificationEntry,
     AddArgEditSpecificationEntry
 } from "@hylimo/diagram-common";
+import { LayoutElement } from "../layoutElement.js";
 
 /**
  * Converts the element to a EditSpecification
@@ -31,10 +31,10 @@ import {
  * @param expressions expression with associated key
  * @returns the generated EditSpecification
  */
-export function generateEdits(element: FullObject): EditSpecification {
+export function applyEdits(layoutElement: LayoutElement): void {
+    const element = layoutElement.element;
     const edits = element.getLocalFieldOrUndefined("edits")!.value;
     assertObject(edits);
-    const res: EditSpecification = {};
     for (const [key, { value }] of edits.fields.entries()) {
         if (key != SemanticFieldNames.PROTO && !isNull(value)) {
             assertObject(value);
@@ -42,10 +42,9 @@ export function generateEdits(element: FullObject): EditSpecification {
             const template = value.getLocalFieldOrUndefined("template")!.value;
             const parsedTemplate: TemplateEntry[] = parseTemplate(template);
             const target = value.getLocalFieldOrUndefined("target")!.value;
-            res[key] = generateEditSpecificationEntry(target, type, parsedTemplate, value);
+            layoutElement.edits[key] = generateEditSpecificationEntry(target, type, parsedTemplate, value);
         }
     }
-    return res;
 }
 
 /**

--- a/packages/diagram/src/layout/engine/layout.ts
+++ b/packages/diagram/src/layout/engine/layout.ts
@@ -149,7 +149,7 @@ export class Layout {
 
     /**
      * Sets the visibility of an element based on its styles and parent visibility
-     * 
+     *
      * @param layoutElement the element to set the visibility for
      */
     private applyVisibility(layoutElement: LayoutElement): void {
@@ -193,14 +193,14 @@ export class Layout {
             isHidden: false,
             isCollapsed: false
         };
-        layoutElement.children.push(
-            ...layoutConfig.getChildren(layoutElement).map((child) => this.create(child, layoutElement))
-        );
         this.elementIdLookup.set(element, id);
         this.layoutElementLookup.set(id, layoutElement);
         this.applyStyles(layoutElement);
         this.applyVisibility(layoutElement);
         applyEdits(layoutElement);
+        layoutElement.children.push(
+            ...layoutConfig.getChildren(layoutElement).map((child) => this.create(child, layoutElement))
+        );
         const layoutInformation = this.computeLayoutInformation(layoutElement.styles);
         layoutElement.layoutInformation = layoutInformation;
         return layoutElement;
@@ -339,6 +339,9 @@ export class Layout {
         size: Size,
         position: Point
     ): { x: number; width: number } {
+        if (element.isCollapsed) {
+            return { x: position.x, width: 0 };
+        }
         const horizontalAlignment = styles.hAlign;
         const marginX = layoutInformation.marginLeft + layoutInformation.marginRight;
         let width = element.requestedSize!.width;
@@ -385,6 +388,9 @@ export class Layout {
         size: Size,
         position: Point
     ): { y: number; height: number } {
+        if (element.isCollapsed) {
+            return { y: position.y, height: 0 };
+        }
         const verticalAlignment = styles.vAlign;
         const marginY = layoutInformation.marginTop + layoutInformation.marginBottom;
         let height = element.requestedSize!.height;

--- a/packages/diagram/src/layout/engine/layout.ts
+++ b/packages/diagram/src/layout/engine/layout.ts
@@ -1,4 +1,4 @@
-import { FullObject, assertString, nativeToList, RuntimeError, BaseObject } from "@hylimo/core";
+import { FullObject, assertString, nativeToList, RuntimeError, BaseObject, InterpreterContext } from "@hylimo/core";
 import { Line, Point, Size } from "@hylimo/diagram-common";
 import { FontCollection } from "../font/fontCollection.js";
 import { StyleList, Selector, SelectorType, Style } from "../../styles.js";
@@ -53,12 +53,14 @@ export class Layout {
      * @param styles styles to possibly apply to elements
      * @param fonts fonts to use
      * @param defaultFontFamily the default font to use
+     * @param context the interpreter context to use for computing styles
      */
     constructor(
         readonly engine: LayoutEngine,
         readonly styles: StyleList,
         readonly fonts: FontCollection,
-        readonly defaultFontFamily: string
+        readonly defaultFontFamily: string,
+        readonly context: InterpreterContext
     ) {}
 
     /**

--- a/packages/diagram/src/layout/engine/layout.ts
+++ b/packages/diagram/src/layout/engine/layout.ts
@@ -545,7 +545,7 @@ class StyleValueParser {
             return variableValue;
         }
         if (variableValue === null) {
-            throw new Error(`Circular dependency while evaluating variable ${name}`);
+            throw new Error(`You cannot define variables such as ${name} with itself`);
         }
         this.variableValues.set(name, null);
         for (const variables of this.variables) {

--- a/packages/diagram/src/layout/engine/layout.ts
+++ b/packages/diagram/src/layout/engine/layout.ts
@@ -132,14 +132,15 @@ export class Layout {
         const styles: Record<string, any> = {};
         for (const attributeConfig of styleAttributes) {
             const name = attributeConfig.name;
-            const elementValue = layoutElement.element.getField(name, this.context)?.value;
-            if (elementValue != undefined && !isNull(elementValue)) {
+            const elementValue = layoutElement.element.getField(name, this.context).value;
+            if (!isNull(elementValue)) {
                 styles[name] = elementValue.toNative();
-            }
-            const styleValue = styleValueParser.getValue(name);
-            if (styleValue != undefined) {
-                layoutElement.element.setField(name, styleValue, this.context);
-                styles[name] = layoutElement.element.getField(name, this.context)?.value?.toNative();
+            } else {
+                const styleValue = styleValueParser.getValue(name);
+                if (styleValue != undefined) {
+                    layoutElement.element.setField(name, styleValue, this.context);
+                    styles[name] = layoutElement.element.getField(name, this.context)?.value?.toNative();
+                }
             }
         }
         layoutElement.styles = styles;

--- a/packages/diagram/src/layout/engine/layoutEngine.ts
+++ b/packages/diagram/src/layout/engine/layoutEngine.ts
@@ -146,7 +146,7 @@ export class LayoutEngine {
      * @param styles the styles to use
      * @param fonts the fonts to use
      * @param context the context to use
-     * @returns the layout with
+     * @returns the layout with the LayoutElement created for {@link element}
      */
     createLayout(
         element: FullObject,

--- a/packages/diagram/src/layout/engine/layoutEngine.ts
+++ b/packages/diagram/src/layout/engine/layoutEngine.ts
@@ -140,7 +140,7 @@ export class LayoutEngine {
     }
 
     /**
-     * Creates a layout with a root elementsd
+     * Creates a layout for a root element
      *
      * @param element the element to layout
      * @param styles the styles to use

--- a/packages/diagram/src/layout/layoutElement.ts
+++ b/packages/diagram/src/layout/layoutElement.ts
@@ -228,11 +228,10 @@ export interface LayoutConfig {
     /**
      * Returns the children of the element
      *
-     * @param layout performs the layout
      * @param element the element to get the children of
      * @returns the children of the element
      */
-    getChildren(layout: Layout, element: LayoutElement): FullObject[];
+    getChildren(element: LayoutElement): FullObject[];
     /**
      * Called to determine the size the element requires
      *
@@ -271,14 +270,6 @@ export interface LayoutConfig {
      * @returns the prototype generation function
      */
     createPrototype(): ExecutableAbstractFunctionExpression;
-    /**
-     * Called to postprocess the extracted styles
-     *
-     * @param element the element to postprocess
-     * @param styles the extracted styles
-     * @returns the postprocessed styles
-     */
-    postprocessStyles(element: LayoutElement, styles: Record<string, any>): Record<string, any>;
     /**
      * Creates a matrix which transforms from the local to the parent coordinate system
      * Can return undefined if the element does not have a parent or if the transformation is the identity matrix

--- a/packages/diagram/src/layout/layoutElement.ts
+++ b/packages/diagram/src/layout/layoutElement.ts
@@ -100,6 +100,24 @@ export interface LayoutInformation {
 }
 
 /**
+ * Controls the visibility of an element
+ */
+export enum Visibility {
+    /**
+     * The element is visible
+     */
+    VISIBLE = "visible",
+    /**
+     * The element is invisible, but still takes up space
+     */
+    HIDDEN = "hidden",
+    /**
+     * The element is invisible, and does not take up space
+     */
+    COLLAPSE = "collapse"
+}
+
+/**
  * The element to layout
  */
 export interface LayoutElement {
@@ -140,10 +158,6 @@ export interface LayoutElement {
      */
     layoutBounds?: Bounds;
     /**
-     * Other required layout data
-     */
-    [key: string]: any;
-    /**
      * Layout information required to be present after style computation
      */
     layoutInformation?: LayoutInformation;
@@ -155,6 +169,19 @@ export interface LayoutElement {
      * Set of classes
      */
     class: Set<string>;
+    /**
+     * If true, this element should not be rendered
+     */
+    isHidden: boolean;
+    /**
+     * If true, this element should be collapsed and not rendered
+     * Implies isHidden
+     */
+    isCollapsed: boolean;
+    /**
+     * Other required layout data
+     */
+    [key: string]: any;
 }
 
 /**

--- a/packages/diagram/src/module/base/diagramModule.ts
+++ b/packages/diagram/src/module/base/diagramModule.ts
@@ -40,7 +40,10 @@ import { LayoutEngine } from "../../layout/engine/layoutEngine.js";
 /**
  * Type for unset, default style values
  */
-const styleValueType = namedType(objectType(new Map([["_type", or(literal("unset"), literal("var"))]])), "unset | var");
+const styleValueType = namedType(
+    objectType(new Map([["_type", or(literal("unset"), literal("var"), literal("calc"))]])),
+    "unset | var"
+);
 
 /**
  * Gets a list of all known style attributes
@@ -64,7 +67,7 @@ function computeAllStyleAttributes(): AttributeConfig[] {
 /**
  * All style atributes
  */
-const allStyleAttributes = computeAllStyleAttributes();
+export const allStyleAttributes = computeAllStyleAttributes();
 
 /**
  * Creates a function which evaluates to the function to create a specific element
@@ -377,13 +380,8 @@ export class DiagramModule implements InterpreterModule {
                     [
                         ...parse(
                             `
-                                (callback, isSelector) = args
+                                (callback, res) = args
                                 this.stylesArgs = args
-                                res = if(isSelector) {
-                                    object(styles = list(), variables = object(), ${allStyleAttributes.map((attr) => `${attr.name} = null`).join(",")})
-                                } {
-                                    object(styles = list())
-                                }
                                 res.type = type
                                 res.cls = cls
                                 res.any = any
@@ -443,7 +441,7 @@ export class DiagramModule implements InterpreterModule {
                         docs: 'Creates a new styles object. Use "cls", "type", and "any" to create rules.',
                         params: [
                             [0, "the callback to invoke", functionType],
-                            [1, "if true, the result can be used as a selector", booleanType]
+                            [1, "the scope object to use which is provided to the callback end returned", objectType()]
                         ],
                         returns: "The created styles object"
                     }

--- a/packages/diagram/src/module/base/diagramModule.ts
+++ b/packages/diagram/src/module/base/diagramModule.ts
@@ -3,6 +3,7 @@ import {
     assertObject,
     assign,
     BaseObject,
+    booleanType,
     DefaultModuleNames,
     ExecutableConstExpression,
     ExecutableExpression,
@@ -41,7 +42,7 @@ import { LayoutEngine } from "../../layout/engine/layoutEngine.js";
  */
 const styleValueType = namedType(
     objectType(new Map([["_type", or(literal("unset"), literal("var"), literal("calc"))]])),
-    "unset | var"
+    "unset | var | calc"
 );
 
 /**
@@ -379,7 +380,7 @@ export class DiagramModule implements InterpreterModule {
                     [
                         ...parse(
                             `
-                                (callback, res) = args
+                                (callback, res, validateStyles) = args
                                 this.stylesArgs = args
                                 res.type = type
                                 res.cls = cls
@@ -432,6 +433,9 @@ export class DiagramModule implements InterpreterModule {
                         ...parse(
                             `
                                 callback.callWithScope(res)
+                                if(validateStyles == true) {
+                                    validateSelector(res, callback)
+                                }
                                 res
                             `
                         )
@@ -440,7 +444,8 @@ export class DiagramModule implements InterpreterModule {
                         docs: 'Creates a new styles object. Use "cls", "type", and "any" to create rules.',
                         params: [
                             [0, "the callback to invoke", functionType],
-                            [1, "the scope object to use which is provided to the callback end returned", objectType()]
+                            [1, "the scope object to use which is provided to the callback end returned", objectType()],
+                            [2, "validate style attributes", optional(booleanType)]
                         ],
                         returns: "The created styles object"
                     }

--- a/packages/diagram/src/module/base/diagramModule.ts
+++ b/packages/diagram/src/module/base/diagramModule.ts
@@ -29,6 +29,7 @@ import { AttributeConfig, ContentCardinality, LayoutConfig } from "../../layout/
 import { layouts } from "../../layout/layouts.js";
 import { elementType } from "./types.js";
 import { DiagramModuleNames } from "../diagramModuleNames.js";
+import { LayoutEngine } from "../../layout/engine/layoutEngine.js";
 
 /**
  * Type for unset, default style values
@@ -182,13 +183,21 @@ function font(name: string, url: string): ExecutableListEntry {
 }
 
 /**
- * Diagram module providing standard diagram UI elements
+ * Diagram module providing default diagram UI elements
  */
-export const diagramModule = InterpreterModule.create(
-    DiagramModuleNames.DIAGRAM,
-    [...Object.values(DefaultModuleNames), DiagramModuleNames.EDIT],
-    [],
-    [
+export class DiagramModule implements InterpreterModule {
+
+    /**
+     * Creates a new diagram module
+     * 
+     * @param layoutEngine the layout engine to use for layouting
+     */
+    constructor(readonly layoutEngine: LayoutEngine) {}
+
+    name = DiagramModuleNames.DIAGRAM;
+    dependencies = [...Object.values(DefaultModuleNames), DiagramModuleNames.EDIT];
+    runtimeDependencies = [];
+    expressions = [
         fun([
             assign("_elementProto", id("object").call({ name: "_type", value: str("element") })),
             assign(
@@ -448,5 +457,5 @@ export const diagramModule = InterpreterModule.create(
                 }
             )
         )
-    ]
-);
+    ];
+}

--- a/packages/diagram/src/module/base/diagramModule.ts
+++ b/packages/diagram/src/module/base/diagramModule.ts
@@ -3,7 +3,6 @@ import {
     assertObject,
     assign,
     BaseObject,
-    booleanType,
     DefaultModuleNames,
     ExecutableConstExpression,
     ExecutableExpression,

--- a/packages/diagram/src/module/base/dslModule.ts
+++ b/packages/diagram/src/module/base/dslModule.ts
@@ -573,6 +573,14 @@ const scopeExpressions: ExecutableExpression[] = [
             Right: "right"
         })
     ),
+    id(SCOPE).assignField(
+        "Visibility",
+        enumObject({
+            Visible: "visible",
+            Hidden: "hidden",
+            Collapse: "collapse"
+        })
+    ),
     ...parse(
         `
             scopeEnhancer(scope)

--- a/packages/diagram/src/module/base/dslModule.ts
+++ b/packages/diagram/src/module/base/dslModule.ts
@@ -14,6 +14,7 @@ import { canvasContentType, elementType } from "./types.js";
 import { CanvasConnection, CanvasElement, DefaultEditTypes } from "@hylimo/diagram-common";
 import { LinePointLayoutConfig } from "../../layout/elements/canvas/linePointLayoutConfig.js";
 import { DiagramModuleNames } from "../diagramModuleNames.js";
+import { allStyleAttributes } from "./diagramModule.js";
 
 /**
  * Identifier for the scope variable
@@ -49,8 +50,8 @@ const scopeExpressions: ExecutableExpression[] = [
             {
                 docs: "Create a absolute point",
                 params: [
-                    [0, "the x coordinate", numberType],
-                    [1, "the y coordinate", numberType]
+                    [0, "the x coordinate", optional(numberType)],
+                    [1, "the y coordinate", optional(numberType)]
                 ],
                 returns: "The created absolute point"
             }
@@ -113,13 +114,20 @@ const scopeExpressions: ExecutableExpression[] = [
                     } {
                         first.class += className
                     }
-                    resultingStyle = styles(second, true)
-                    resultingStyle.selectorType = "class"
-                    resultingStyle.selectorValue = className
+                    resultingStyle = styles(
+                        second,
+                        object(
+                            selectorType = "class",
+                            selectorValue = className,
+                            styles = list(),
+                            class = first.class,
+                            ${allStyleAttributes.map((attr) => `${attr.name} = null`).join(",")}
+                        )
+                    )
                     scope.internal.styles.styles.add(resultingStyle)
                     first
                 } {
-                    resultStyles = styles(first, false)
+                    resultStyles = styles(first, object(styles = list()))
                     scope.internal.styles.styles.addAll(resultStyles.styles)
                 }
             `,

--- a/packages/diagram/src/module/base/dslModule.ts
+++ b/packages/diagram/src/module/base/dslModule.ts
@@ -32,7 +32,7 @@ const scopeExpressions: ExecutableExpression[] = [
                 contents = list(),
                 internal = object(
                     classCounter = 0,
-                    styles = styles({ })
+                    styles = object(styles = list())
                 )
             )
         `
@@ -113,21 +113,13 @@ const scopeExpressions: ExecutableExpression[] = [
                     } {
                         first.class += className
                     }
-                    scope.styles {
-                        cls(className) {
-                            this.any = any
-                            this.cls = cls
-                            this.type = type
-                            this.unset = unset
-                            this.var = var
-                            this.vars = vars
-                            this.class = first.class
-                            second.callWithScope(this)
-                        }
-                    }
+                    resultingStyle = styles(second, true)
+                    resultingStyle.selectorType = "class"
+                    resultingStyle.selectorValue = className
+                    scope.internal.styles.styles.add(resultingStyle)
                     first
                 } {
-                    resultStyles = styles(first)
+                    resultStyles = styles(first, false)
                     scope.internal.styles.styles.addAll(resultStyles.styles)
                 }
             `,

--- a/packages/diagram/src/module/base/dslModule.ts
+++ b/packages/diagram/src/module/base/dslModule.ts
@@ -122,7 +122,8 @@ const scopeExpressions: ExecutableExpression[] = [
                             styles = list(),
                             class = first.class,
                             ${allStyleAttributes.map((attr) => `${attr.name} = null`).join(",")}
-                        )
+                        ),
+                        true
                     )
                     scope.internal.styles.styles.add(resultingStyle)
                     first

--- a/packages/diagram/src/module/base/editModule.ts
+++ b/packages/diagram/src/module/base/editModule.ts
@@ -9,13 +9,13 @@ import {
     IdentifierExpression,
     InterpreterContext,
     InterpreterModule,
-    InvocationExpression,
     jsFun,
     NumberLiteralExpression,
     StringObject,
     FunctionExpression,
     RuntimeError,
-    MissingArgumentSource
+    MissingArgumentSource,
+    OperatorExpression
 } from "@hylimo/core";
 import { DiagramModuleNames } from "../diagramModuleNames.js";
 
@@ -209,22 +209,21 @@ export const editModule = InterpreterModule.create(
                         return generateReplaceOrAddArgEdit(target, { value: context.newString(expression) }, context);
                     }
 
-                    if (target instanceof InvocationExpression) {
-                        const operator = target.target;
+                    if (target instanceof OperatorExpression) {
+                        const operator = target.operator;
                         if (
                             operator instanceof IdentifierExpression &&
                             (operator.identifier === "+" || operator.identifier === "-") &&
-                            target.argumentExpressions.length === 2 &&
-                            target.argumentExpressions[1].value instanceof NumberLiteralExpression
+                            target.right instanceof NumberLiteralExpression
                         ) {
-                            const rightHandValue = target.argumentExpressions[1].value.value;
+                            const rightHandValue = target.right.value;
                             const replacedValue = operator.identifier === "+" ? rightHandValue : -rightHandValue;
                             const sum = `${replacedValue} + ${deltaExp}`;
                             const operatorAndSum = `($res := ${sum}; $res >= 0 ? " + " & $res : " - " & -$res)`;
                             const operatorAndSumExp = context.newString(operatorAndSum);
                             return generateReplaceEdit(
                                 target,
-                                [target.argumentExpressions[0].value.toWrapperObject(context), operatorAndSumExp],
+                                [target.left.toWrapperObject(context), operatorAndSumExp],
                                 context
                             );
                         }

--- a/packages/diagram/src/module/diagramModules.ts
+++ b/packages/diagram/src/module/diagramModules.ts
@@ -13,16 +13,12 @@ import { LayoutEngine } from "../layout/engine/layoutEngine.js";
  * - diagram
  * - dsl
  * - edit
- * 
+ *
  * @param layoutEngine the layout engine to use for the diagram module
  * @returns the base diagram modules
  */
-export function createBaseDiagramModules(layoutEngine: LayoutEngine) : InterpreterModule[] {
-    return [
-        new DiagramModule(layoutEngine),
-        dslModule,
-        editModule
-    ]
+export function createBaseDiagramModules(layoutEngine: LayoutEngine): InterpreterModule[] {
+    return [new DiagramModule(layoutEngine), dslModule, editModule];
 }
 
 /**
@@ -32,9 +28,4 @@ export function createBaseDiagramModules(layoutEngine: LayoutEngine) : Interpret
  * - UML component diagram: componentDiagram
  * - (arbitrary) UML diagram: umlDiagram
  */
-export const defaultDiagramModules = [
-    baseDiagramModule,
-    classDiagramModule,
-    componentDiagramModule,
-    umlDiagramModule
-];
+export const defaultDiagramModules = [baseDiagramModule, classDiagramModule, componentDiagramModule, umlDiagramModule];

--- a/packages/diagram/src/module/diagramModules.ts
+++ b/packages/diagram/src/module/diagramModules.ts
@@ -1,10 +1,29 @@
-import { diagramModule } from "./base/diagramModule.js";
+import { InterpreterModule } from "@hylimo/core";
+import { DiagramModule } from "./base/diagramModule.js";
 import { dslModule } from "./base/dslModule.js";
 import { editModule } from "./base/editModule.js";
 import { baseDiagramModule } from "./diagrams/baseDiagramModule.js";
 import { classDiagramModule } from "./diagrams/classDiagramModule.js";
 import { componentDiagramModule } from "./diagrams/componentDiagramModule.js";
 import { umlDiagramModule } from "./diagrams/umlDiagramModule.js";
+import { LayoutEngine } from "../layout/engine/layoutEngine.js";
+
+/**
+ * Provides / creates the base diagram modules, including
+ * - diagram
+ * - dsl
+ * - edit
+ * 
+ * @param layoutEngine the layout engine to use for the diagram module
+ * @returns the base diagram modules
+ */
+export function createBaseDiagramModules(layoutEngine: LayoutEngine) : InterpreterModule[] {
+    return [
+        new DiagramModule(layoutEngine),
+        dslModule,
+        editModule
+    ]
+}
 
 /**
  * Default diagram modules, including
@@ -14,9 +33,6 @@ import { umlDiagramModule } from "./diagrams/umlDiagramModule.js";
  * - (arbitrary) UML diagram: umlDiagram
  */
 export const defaultDiagramModules = [
-    diagramModule,
-    dslModule,
-    editModule,
     baseDiagramModule,
     classDiagramModule,
     componentDiagramModule,

--- a/packages/diagram/src/module/diagrams/content/uml/classifier/ports.ts
+++ b/packages/diagram/src/module/diagrams/content/uml/classifier/ports.ts
@@ -34,8 +34,9 @@ export const portsModule = InterpreterModule.create(
                                         portElement = canvasElement(
                                             class = list("port-element"),
                                             content = rect(class = list("port")),
-                                            pos = canvasScope.lpos(element, pos, args.dist ?? -1)
+                                            pos = canvasScope.lpos(element, pos)
                                         )
+                                        portElement.pos.class = list("port-pos")
                                         
                                         result = []
                                         scope.internal.providesRequiresContentHandler[0](
@@ -60,11 +61,6 @@ export const portsModule = InterpreterModule.create(
                                                 1,
                                                 "Optional function to define the content of the port",
                                                 optional(functionType)
-                                            ],
-                                            [
-                                                "dist",
-                                                "Distance from the outline, defaults to half of the default stroke width (width of the outline). Needs to be adapted if the width of outline is not the default value",
-                                                optional(numberType)
                                             ]
                                         ],
                                         returns: "The created port element"
@@ -97,6 +93,9 @@ export const portsModule = InterpreterModule.create(
                         cls("port") {
                             fill = var("background")
                         }
+                    }
+                    cls("port-pos") {
+                        distance = var("strokeWidth") / -2
                     }
                 }
             `

--- a/packages/diagram/src/module/diagrams/content/uml/classifier/ports.ts
+++ b/packages/diagram/src/module/diagrams/content/uml/classifier/ports.ts
@@ -1,4 +1,4 @@
-import { fun, functionType, id, InterpreterModule, numberType, object, optional, parse } from "@hylimo/core";
+import { fun, functionType, id, InterpreterModule, object, optional, parse } from "@hylimo/core";
 import { SCOPE } from "../../../../base/dslModule.js";
 import { LinePointLayoutConfig } from "../../../../../layout/elements/canvas/linePointLayoutConfig.js";
 

--- a/packages/diagram/src/module/diagrams/content/uml/classifier/providesAndRequires.ts
+++ b/packages/diagram/src/module/diagrams/content/uml/classifier/providesAndRequires.ts
@@ -5,6 +5,8 @@ import { canvasContentType } from "../../../../base/types.js";
 
 /**
  * Type for the optional name label position
+ * The first value is the x offset, the second the y offset,
+ * both relative to the connection end.
  */
 const nameLabelPosType = optional(
     objectType(

--- a/packages/diagram/src/module/diagrams/content/uml/classifier/providesAndRequires.ts
+++ b/packages/diagram/src/module/diagrams/content/uml/classifier/providesAndRequires.ts
@@ -1,4 +1,4 @@
-import { fun, id, InterpreterModule, numberType, object, optional, parse, stringType } from "@hylimo/core";
+import { fun, id, InterpreterModule, numberType, object, objectType, optional, parse, stringType } from "@hylimo/core";
 import { LinePointLayoutConfig } from "../../../../../layout/elements/canvas/linePointLayoutConfig.js";
 import { SCOPE } from "../../../../base/dslModule.js";
 import { canvasContentType } from "../../../../base/types.js";
@@ -57,6 +57,15 @@ export const providesAndRequiresModule = InterpreterModule.create(
                                         )
                                         interfaceConnection.contents[0]._verticalPos = 1
                                         scope.internal.registerInDiagramScope(name, interfaceConnection)
+                                        (xLabelOffset, yLabelOffset) = args.namePos ?? [null, null]
+                                        nameLabelPos = canvasScope.rpos(interfaceConnection, xLabelOffset, yLabelOffset)
+                                        nameLabelPos.class = list("provided-interface-label-pos")
+                                        nameLabel = canvasElement(
+                                            content = text(contents = list(span(text = name)), class = list("label")),
+                                            class = list("label-element"),
+                                            pos = nameLabelPos
+                                        )
+                                        scope.internal.registerCanvasContent(nameLabel, args, canvasScope)
                                         interfaceConnection
                                     `,
                                     {
@@ -77,6 +86,11 @@ export const providesAndRequiresModule = InterpreterModule.create(
                                                 "dist",
                                                 "Distance of the provided interface to the classifier",
                                                 optional(numberType)
+                                            ],
+                                            [
+                                                "namePos",
+                                                "X and Y offset for the name label",
+                                                optional(objectType(new Map([[0, numberType], [1, numberType]])))
                                             ]
                                         ],
                                         returns: "The created provided interface"
@@ -112,6 +126,15 @@ export const providesAndRequiresModule = InterpreterModule.create(
                                         )
                                         interfaceConnection.contents[0]._verticalPos = 1
                                         scope.internal.registerInDiagramScope(name, interfaceConnection)
+                                        (xLabelOffset, yLabelOffset) = args.namePos ?? [null, null]
+                                        nameLabelPos = canvasScope.rpos(interfaceConnection, xLabelOffset, yLabelOffset)
+                                        nameLabelPos.class = list("required-interface-label-pos")
+                                        nameLabel = canvasElement(
+                                            content = text(contents = list(span(text = name)), class = list("label")),
+                                            class = list("label-element"),
+                                            pos = nameLabelPos
+                                        )
+                                        scope.internal.registerCanvasContent(nameLabel, args, canvasScope)
                                         interfaceConnection
                                     `,
                                     {
@@ -128,6 +151,11 @@ export const providesAndRequiresModule = InterpreterModule.create(
                                                 "dist",
                                                 "Distance of the required interface to the classifier",
                                                 optional(numberType)
+                                            ],
+                                            [
+                                                "namePos",
+                                                "X and Y offset for the name label",
+                                                optional(objectType(new Map([[0, numberType], [1, numberType]])))
                                             ]
                                         ],
                                         returns: "The created required interface"
@@ -187,6 +215,12 @@ export const providesAndRequiresModule = InterpreterModule.create(
                             refX = 0.5
                             refY = 0.5
                         }
+                    }
+                    cls("provided-interface-label-pos") {
+                        offsetY = var("providedInterfaceSize") / 2
+                    }
+                    cls("required-interface-label-pos") {
+                        offsetY = var("requiredInterfaceSize") / 2
                     }
                 }
             `

--- a/packages/diagram/src/module/diagrams/content/uml/classifier/providesAndRequires.ts
+++ b/packages/diagram/src/module/diagrams/content/uml/classifier/providesAndRequires.ts
@@ -90,7 +90,14 @@ export const providesAndRequiresModule = InterpreterModule.create(
                                             [
                                                 "namePos",
                                                 "X and Y offset for the name label",
-                                                optional(objectType(new Map([[0, numberType], [1, numberType]])))
+                                                optional(
+                                                    objectType(
+                                                        new Map([
+                                                            [0, numberType],
+                                                            [1, numberType]
+                                                        ])
+                                                    )
+                                                )
                                             ]
                                         ],
                                         returns: "The created provided interface"
@@ -155,7 +162,14 @@ export const providesAndRequiresModule = InterpreterModule.create(
                                             [
                                                 "namePos",
                                                 "X and Y offset for the name label",
-                                                optional(objectType(new Map([[0, numberType], [1, numberType]])))
+                                                optional(
+                                                    objectType(
+                                                        new Map([
+                                                            [0, numberType],
+                                                            [1, numberType]
+                                                        ])
+                                                    )
+                                                )
                                             ]
                                         ],
                                         returns: "The created required interface"

--- a/packages/diagram/src/module/diagrams/content/uml/classifier/providesAndRequires.ts
+++ b/packages/diagram/src/module/diagrams/content/uml/classifier/providesAndRequires.ts
@@ -4,6 +4,18 @@ import { SCOPE } from "../../../../base/dslModule.js";
 import { canvasContentType } from "../../../../base/types.js";
 
 /**
+ * Type for the optional name label position
+ */
+const nameLabelPosType = optional(
+    objectType(
+        new Map([
+            [0, optional(numberType)],
+            [1, optional(numberType)]
+        ])
+    )
+);
+
+/**
  * Module providing helper function to create provided and required interfaces for a classifier
  */
 export const providesAndRequiresModule = InterpreterModule.create(
@@ -87,18 +99,7 @@ export const providesAndRequiresModule = InterpreterModule.create(
                                                 "Distance of the provided interface to the classifier",
                                                 optional(numberType)
                                             ],
-                                            [
-                                                "namePos",
-                                                "X and Y offset for the name label",
-                                                optional(
-                                                    objectType(
-                                                        new Map([
-                                                            [0, numberType],
-                                                            [1, numberType]
-                                                        ])
-                                                    )
-                                                )
-                                            ]
+                                            ["namePos", "X and Y offset for the name label", nameLabelPosType]
                                         ],
                                         returns: "The created provided interface"
                                     }
@@ -159,18 +160,7 @@ export const providesAndRequiresModule = InterpreterModule.create(
                                                 "Distance of the required interface to the classifier",
                                                 optional(numberType)
                                             ],
-                                            [
-                                                "namePos",
-                                                "X and Y offset for the name label",
-                                                optional(
-                                                    objectType(
-                                                        new Map([
-                                                            [0, numberType],
-                                                            [1, numberType]
-                                                        ])
-                                                    )
-                                                )
-                                            ]
+                                            ["namePos", "X and Y offset for the name label", nameLabelPosType]
                                         ],
                                         returns: "The created required interface"
                                     }

--- a/packages/language-server/src/completion/completionEngine.ts
+++ b/packages/language-server/src/completion/completionEngine.ts
@@ -29,11 +29,7 @@ export class CompletionEngine {
      * @param position the position of the cursor
      * @returns the generated complete items or undefined if no items could be generated
      */
-    complete(
-        text: string,
-        config: DiagramConfig,
-        position: number
-    ): CompletionItem[] | undefined {
+    complete(text: string, config: DiagramConfig, position: number): CompletionItem[] | undefined {
         const parserResult = this.parser.parse(text);
         if (parserResult.ast == undefined) {
             return undefined;
@@ -41,7 +37,7 @@ export class CompletionEngine {
         const toExecutableTransformer = new CompletionAstTransformer(position);
         const executableAst = parserResult.ast.map((expression) => toExecutableTransformer.visit(expression));
         try {
-            this.diagramEngine.renderInternal(executableAst, config)
+            this.diagramEngine.execute(executableAst, config);
         } catch (e: any) {
             if (CompletionError.isCompletionError(e)) {
                 return e.completionItems;

--- a/packages/language-server/src/diagram/local/localDiagramImplementation.ts
+++ b/packages/language-server/src/diagram/local/localDiagramImplementation.ts
@@ -130,7 +130,7 @@ export class LocalDiagramImplementation extends DiagramImplementation {
         this.document = TextDocument.create("", "sys", 0, source);
         const items = this.utils.completionEngine.complete(
             this.document.getText(),
-            this.utils.diagramEngine.convertConfig(config),
+            config,
             this.document.offsetAt(position)
         );
         return items?.map((item) => {

--- a/packages/language-server/src/languageServer.ts
+++ b/packages/language-server/src/languageServer.ts
@@ -111,17 +111,15 @@ export class LanguageServer {
         this.connection.onInitialize(this.onInitialize.bind(this));
         this.diagramServerManager = new DiagramServerManager(this.connection);
         this.textDocuments.listen(this.connection);
-        const interpreterModules = [...defaultDiagramModules, ...config.additionalInterpreterModules];
-        const interpreter = new Interpreter(interpreterModules, defaultModules, config.maxExecutionSteps);
         const parser = new Parser();
+        const diagramEngine = new DiagramEngine(config.additionalInterpreterModules, config.maxExecutionSteps);
         this.diagramUtils = {
             config: new Config(config.defaultConfig),
             connection: this.connection,
-            interpreter,
             parser,
-            diagramEngine: new DiagramEngine(parser, interpreter, new LayoutEngine()),
+            diagramEngine,
             diagramServerManager: this.diagramServerManager,
-            completionEngine: new CompletionEngine(interpreter)
+            completionEngine: new CompletionEngine(diagramEngine)
         };
         this.layoutedDiagramManager = new RemoteDiagramImplementationManager(this.diagramUtils);
         this.formatter = new Formatter(this.diagramUtils.parser);

--- a/packages/language-server/src/languageServer.ts
+++ b/packages/language-server/src/languageServer.ts
@@ -1,4 +1,4 @@
-import { InterpreterModule, Interpreter, Parser, defaultModules } from "@hylimo/core";
+import { InterpreterModule, Parser } from "@hylimo/core";
 import {
     CompletionItem,
     CompletionParams,
@@ -15,7 +15,7 @@ import {
 import { TextDocument, TextDocumentContentChangeEvent } from "vscode-languageserver-textdocument";
 import { Diagram } from "./diagram/diagram.js";
 import { Formatter } from "./format/formatter.js";
-import { defaultDiagramModules, DiagramEngine, LayoutEngine } from "@hylimo/diagram";
+import { DiagramEngine } from "@hylimo/diagram";
 import { DiagramServerManager } from "./diagramServerManager.js";
 import {
     DiagramActionNotification,

--- a/packages/language-server/src/sharedDiagramUtils.ts
+++ b/packages/language-server/src/sharedDiagramUtils.ts
@@ -18,10 +18,6 @@ export interface SharedDiagramUtils {
      */
     readonly connection: Connection;
     /**
-     * Interpreter to execute scripts
-     */
-    readonly interpreter: Interpreter;
-    /**
      * Parser to parse scripts
      */
     readonly parser: Parser;

--- a/packages/language-server/src/sharedDiagramUtils.ts
+++ b/packages/language-server/src/sharedDiagramUtils.ts
@@ -1,4 +1,4 @@
-import { Interpreter, Parser } from "@hylimo/core";
+import { Parser } from "@hylimo/core";
 import { DiagramEngine } from "@hylimo/diagram";
 import { Connection } from "vscode-languageserver";
 import { DiagramServerManager } from "./diagramServerManager.js";


### PR DESCRIPTION
## technical changes
- make operators more resiliant against missing self-argument
- layouting is not performed during the execution of the code
    - this allows doing style evaluation there, which allows for edit support (see new features)
    - this allows implementing calc expressions (see new features) in a more general way
- diagram-ui css styles are now better scoped to the affected component (less style leaks)

## new features
- values declared in style rules are now graphically editable
- calc expressions in style rules
    - no special syntax needed, just use regular operators in combination with other calc or var expressions
    - most regular operators supported, except short-circuit `&&` and `||` operators
- coordinates of apos, rpos aned lpos can now be affected by styles
    - allows using vars and calc expressions there
- visibility for most diagram elements
    - visible (default)
    - hidden (not visible, but still used during layout)
    - collapse (not visible, not used during layout)
- make markers selectable and movable (moves the associated end point of the connection)
- non-short circuit `&` and `|` operators


## bugfixes
- fix additive edits

## issues
- closes #87 

## future work
- in theory, when an attribute is set by a style rule and there exists and edit before, the edit could still be used
    - assuming the edit sets the attribute regularly and not by a style rule
    - however, this is not implemented yet due to semantic issues with diff-based edits (mainly translation move edits)