### PR TITLE
Remove `author` metadata

### DIFF
--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -52,13 +52,6 @@ export default withPwa(
                     content: "Graphical and text editor for diagrams, especially UML diagrams"
                 }
             ],
-            [
-                "meta",
-                {
-                    name: "author",
-                    content: "Niklas Krieger and Leon Hofmeister"
-                }
-            ],
             ["link", { rel: "icon", href: "/favicon.ico" }],
             [
                 "meta",


### PR DESCRIPTION
Apparently, this tag is used in different ways by some applications compared to what I expected