### PR TITLE
Add Unicode support and template expressions for strings 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@types/wicg-file-system-access": "^2023.10.5",
                 "@typescript-eslint/eslint-plugin": "^8.14.0",
                 "@typescript-eslint/parser": "^8.14.0",
-                "eslint": "^9.15.0",
+                "eslint": "^9.14.0",
                 "eslint-config-prettier": "^9.1.0",
                 "eslint-plugin-prettier": "^5.2.1",
                 "prettier": "^3.3.3",
@@ -3174,11 +3174,10 @@
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.19.0",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.0.tgz",
-            "integrity": "sha512-zdHg2FPIFNKPdcHWtiNT+jEFCHYVplAXRDlQDyqy0zGx/q2parwh7brGJSiTxRk/TSMkbM//zt/f5CHgyTyaSQ==",
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.18.0.tgz",
+            "integrity": "sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==",
             "dev": true,
-            "license": "Apache-2.0",
             "dependencies": {
                 "@eslint/object-schema": "^2.1.4",
                 "debug": "^4.3.1",
@@ -3193,7 +3192,6 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3204,7 +3202,6 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -3213,11 +3210,10 @@
             }
         },
         "node_modules/@eslint/core": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.0.tgz",
-            "integrity": "sha512-7ATR9F0e4W85D/0w7cU0SNj7qkAexMG+bAHEZOjo9akvGuhHE2m7umzWzfnpa0XAg5Kxc1BWmtPMV67jJ+9VUg==",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.7.0.tgz",
+            "integrity": "sha512-xp5Jirz5DyPYlPiKat8jaq0EmYvDXKKpzTbxXMpT9eqlRJkRKIz9AGMdlvYjih+im+QlhWrpvVjl8IPC/lHlUw==",
             "dev": true,
-            "license": "Apache-2.0",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
@@ -3271,11 +3267,10 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.15.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.15.0.tgz",
-            "integrity": "sha512-tMTqrY+EzbXmKJR5ToI8lxu7jaN5EdmrBFJpQk5JmSlyLsx6o4t27r883K5xsLuCYCpfKBCGswMSWXsM+jB7lg==",
+            "version": "9.14.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.14.0.tgz",
+            "integrity": "sha512-pFoEtFWCPyDOl+C6Ift+wC7Ro89otjigCf5vcuWqWgqNSQbRrpjSvdeE6ofLz4dHmyxD5f7gIdGT4+p36L6Twg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
@@ -3285,7 +3280,6 @@
             "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.4.tgz",
             "integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
             "dev": true,
-            "license": "Apache-2.0",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
@@ -5932,27 +5926,26 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.15.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.15.0.tgz",
-            "integrity": "sha512-7CrWySmIibCgT1Os28lUU6upBshZ+GxybLOrmRzi08kS8MBuO8QA7pXEgYgY5W8vK3e74xv0lpjo9DbaGU9Rkw==",
+            "version": "9.14.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.14.0.tgz",
+            "integrity": "sha512-c2FHsVBr87lnUtjP4Yhvk4yEhKrQavGafRA/Se1ouse8PfbfC/Qh9Mxa00yWsZRlqeUB9raXip0aiiUZkgnr9g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
-                "@eslint/config-array": "^0.19.0",
-                "@eslint/core": "^0.9.0",
-                "@eslint/eslintrc": "^3.2.0",
-                "@eslint/js": "9.15.0",
-                "@eslint/plugin-kit": "^0.2.3",
+                "@eslint/config-array": "^0.18.0",
+                "@eslint/core": "^0.7.0",
+                "@eslint/eslintrc": "^3.1.0",
+                "@eslint/js": "9.14.0",
+                "@eslint/plugin-kit": "^0.2.0",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
-                "@humanwhocodes/retry": "^0.4.1",
+                "@humanwhocodes/retry": "^0.4.0",
                 "@types/estree": "^1.0.6",
                 "@types/json-schema": "^7.0.15",
                 "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
-                "cross-spawn": "^7.0.5",
+                "cross-spawn": "^7.0.2",
                 "debug": "^4.3.2",
                 "escape-string-regexp": "^4.0.0",
                 "eslint-scope": "^8.2.0",
@@ -5971,7 +5964,8 @@
                 "lodash.merge": "^4.6.2",
                 "minimatch": "^3.1.2",
                 "natural-compare": "^1.4.0",
-                "optionator": "^0.9.3"
+                "optionator": "^0.9.3",
+                "text-table": "^0.2.0"
             },
             "bin": {
                 "eslint": "bin/eslint.js"
@@ -9248,6 +9242,12 @@
             "dev": true,
             "license": "MIT",
             "peer": true
+        },
+        "node_modules/text-table": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+            "dev": true
         },
         "node_modules/tiny-inflate": {
             "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,14 @@
             ],
             "devDependencies": {
                 "@types/wicg-file-system-access": "^2023.10.5",
-                "@typescript-eslint/eslint-plugin": "^8.14.0",
-                "@typescript-eslint/parser": "^8.14.0",
-                "eslint": "^9.14.0",
+                "@typescript-eslint/eslint-plugin": "^8.15.0",
+                "@typescript-eslint/parser": "^8.15.0",
+                "eslint": "^9.15.0",
                 "eslint-config-prettier": "^9.1.0",
                 "eslint-plugin-prettier": "^5.2.1",
                 "prettier": "^3.3.3",
                 "typescript": "^5.6.3",
-                "typescript-eslint": "^8.14.0"
+                "typescript-eslint": "^8.15.0"
             }
         },
         "node_modules/@algolia/autocomplete-core": {
@@ -3174,9 +3174,9 @@
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.18.0.tgz",
-            "integrity": "sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==",
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.0.tgz",
+            "integrity": "sha512-zdHg2FPIFNKPdcHWtiNT+jEFCHYVplAXRDlQDyqy0zGx/q2parwh7brGJSiTxRk/TSMkbM//zt/f5CHgyTyaSQ==",
             "dev": true,
             "dependencies": {
                 "@eslint/object-schema": "^2.1.4",
@@ -3210,9 +3210,9 @@
             }
         },
         "node_modules/@eslint/core": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.7.0.tgz",
-            "integrity": "sha512-xp5Jirz5DyPYlPiKat8jaq0EmYvDXKKpzTbxXMpT9eqlRJkRKIz9AGMdlvYjih+im+QlhWrpvVjl8IPC/lHlUw==",
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.0.tgz",
+            "integrity": "sha512-7ATR9F0e4W85D/0w7cU0SNj7qkAexMG+bAHEZOjo9akvGuhHE2m7umzWzfnpa0XAg5Kxc1BWmtPMV67jJ+9VUg==",
             "dev": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3267,9 +3267,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.14.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.14.0.tgz",
-            "integrity": "sha512-pFoEtFWCPyDOl+C6Ift+wC7Ro89otjigCf5vcuWqWgqNSQbRrpjSvdeE6ofLz4dHmyxD5f7gIdGT4+p36L6Twg==",
+            "version": "9.15.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.15.0.tgz",
+            "integrity": "sha512-tMTqrY+EzbXmKJR5ToI8lxu7jaN5EdmrBFJpQk5JmSlyLsx6o4t27r883K5xsLuCYCpfKBCGswMSWXsM+jB7lg==",
             "dev": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3497,7 +3497,6 @@
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "2.0.5",
                 "run-parallel": "^1.1.9"
@@ -3511,7 +3510,6 @@
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
             "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 8"
             }
@@ -3521,7 +3519,6 @@
             "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
@@ -4188,17 +4185,16 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.14.0.tgz",
-            "integrity": "sha512-tqp8H7UWFaZj0yNO6bycd5YjMwxa6wIHOLZvWPkidwbgLCsBMetQoGj7DPuAlWa2yGO3H48xmPwjhsSPPCGU5w==",
+            "version": "8.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.15.0.tgz",
+            "integrity": "sha512-+zkm9AR1Ds9uLWN3fkoeXgFppaQ+uEVtfOV62dDmsy9QCNqlRHWNEck4yarvRNrvRcHQLGfqBNui3cimoz8XAg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.14.0",
-                "@typescript-eslint/type-utils": "8.14.0",
-                "@typescript-eslint/utils": "8.14.0",
-                "@typescript-eslint/visitor-keys": "8.14.0",
+                "@typescript-eslint/scope-manager": "8.15.0",
+                "@typescript-eslint/type-utils": "8.15.0",
+                "@typescript-eslint/utils": "8.15.0",
+                "@typescript-eslint/visitor-keys": "8.15.0",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.3.1",
                 "natural-compare": "^1.4.0",
@@ -4222,16 +4218,15 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.14.0.tgz",
-            "integrity": "sha512-2p82Yn9juUJq0XynBXtFCyrBDb6/dJombnz6vbo6mgQEtWHfvHbQuEa9kAOVIt1c9YFwi7H6WxtPj1kg+80+RA==",
+            "version": "8.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.15.0.tgz",
+            "integrity": "sha512-7n59qFpghG4uazrF9qtGKBZXn7Oz4sOMm8dwNWDQY96Xlm2oX67eipqcblDj+oY1lLCbf1oltMZFpUso66Kl1A==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.14.0",
-                "@typescript-eslint/types": "8.14.0",
-                "@typescript-eslint/typescript-estree": "8.14.0",
-                "@typescript-eslint/visitor-keys": "8.14.0",
+                "@typescript-eslint/scope-manager": "8.15.0",
+                "@typescript-eslint/types": "8.15.0",
+                "@typescript-eslint/typescript-estree": "8.15.0",
+                "@typescript-eslint/visitor-keys": "8.15.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -4251,14 +4246,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.14.0.tgz",
-            "integrity": "sha512-aBbBrnW9ARIDn92Zbo7rguLnqQ/pOrUguVpbUwzOhkFg2npFDwTgPGqFqE0H5feXcOoJOfX3SxlJaKEVtq54dw==",
+            "version": "8.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.15.0.tgz",
+            "integrity": "sha512-QRGy8ADi4J7ii95xz4UoiymmmMd/zuy9azCaamnZ3FM8T5fZcex8UfJcjkiEZjJSztKfEBe3dZ5T/5RHAmw2mA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.14.0",
-                "@typescript-eslint/visitor-keys": "8.14.0"
+                "@typescript-eslint/types": "8.15.0",
+                "@typescript-eslint/visitor-keys": "8.15.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4269,14 +4263,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.14.0.tgz",
-            "integrity": "sha512-Xcz9qOtZuGusVOH5Uk07NGs39wrKkf3AxlkK79RBK6aJC1l03CobXjJbwBPSidetAOV+5rEVuiT1VSBUOAsanQ==",
+            "version": "8.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.15.0.tgz",
+            "integrity": "sha512-UU6uwXDoI3JGSXmcdnP5d8Fffa2KayOhUUqr/AiBnG1Gl7+7ut/oyagVeSkh7bxQ0zSXV9ptRh/4N15nkCqnpw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.14.0",
-                "@typescript-eslint/utils": "8.14.0",
+                "@typescript-eslint/typescript-estree": "8.15.0",
+                "@typescript-eslint/utils": "8.15.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.3.0"
             },
@@ -4287,6 +4280,9 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0"
+            },
             "peerDependenciesMeta": {
                 "typescript": {
                     "optional": true
@@ -4294,11 +4290,10 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.14.0.tgz",
-            "integrity": "sha512-yjeB9fnO/opvLJFAsPNYlKPnEM8+z4og09Pk504dkqonT02AyL5Z9SSqlE0XqezS93v6CXn49VHvB2G7XSsl0g==",
+            "version": "8.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.15.0.tgz",
+            "integrity": "sha512-n3Gt8Y/KyJNe0S3yDCD2RVKrHBC4gTUcLTebVBXacPy091E6tNspFLKRXlk3hwT4G55nfr1n2AdFqi/XMxzmPQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
@@ -4308,14 +4303,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.14.0.tgz",
-            "integrity": "sha512-OPXPLYKGZi9XS/49rdaCbR5j/S14HazviBlUQFvSKz3npr3NikF+mrgK7CFVur6XEt95DZp/cmke9d5i3vtVnQ==",
+            "version": "8.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.15.0.tgz",
+            "integrity": "sha512-1eMp2JgNec/niZsR7ioFBlsh/Fk0oJbhaqO0jRyQBMgkz7RrFfkqF9lYYmBoGBaSiLnu8TAPQTwoTUiSTUW9dg==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "dependencies": {
-                "@typescript-eslint/types": "8.14.0",
-                "@typescript-eslint/visitor-keys": "8.14.0",
+                "@typescript-eslint/types": "8.15.0",
+                "@typescript-eslint/visitor-keys": "8.15.0",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -4337,16 +4331,15 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.14.0.tgz",
-            "integrity": "sha512-OGqj6uB8THhrHj0Fk27DcHPojW7zKwKkPmHXHvQ58pLYp4hy8CSUdTKykKeh+5vFqTTVmjz0zCOOPKRovdsgHA==",
+            "version": "8.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.15.0.tgz",
+            "integrity": "sha512-k82RI9yGhr0QM3Dnq+egEpz9qB6Un+WLYhmoNcvl8ltMEededhh7otBVVIDDsEEttauwdY/hQoSsOv13lxrFzQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "8.14.0",
-                "@typescript-eslint/types": "8.14.0",
-                "@typescript-eslint/typescript-estree": "8.14.0"
+                "@typescript-eslint/scope-manager": "8.15.0",
+                "@typescript-eslint/types": "8.15.0",
+                "@typescript-eslint/typescript-estree": "8.15.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4357,17 +4350,21 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.14.0.tgz",
-            "integrity": "sha512-vG0XZo8AdTH9OE6VFRwAZldNc7qtJ/6NLGWak+BtENuEUXGZgFpihILPiBvKXvJ2nFu27XNGC6rKiwuaoMbYzQ==",
+            "version": "8.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.15.0.tgz",
+            "integrity": "sha512-h8vYOulWec9LhpwfAdZf2bjr8xIp0KNKnpgqSz0qqYYKAW/QZKw3ktRndbiAtUz4acH4QLQavwZBYCc0wulA/Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.14.0",
-                "eslint-visitor-keys": "^3.4.3"
+                "@typescript-eslint/types": "8.15.0",
+                "eslint-visitor-keys": "^4.2.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4375,6 +4372,18 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+            "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+            "dev": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/@ungap/structured-clone": {
@@ -5095,7 +5104,6 @@
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "fill-range": "^7.1.1"
             },
@@ -5926,26 +5934,26 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.14.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.14.0.tgz",
-            "integrity": "sha512-c2FHsVBr87lnUtjP4Yhvk4yEhKrQavGafRA/Se1ouse8PfbfC/Qh9Mxa00yWsZRlqeUB9raXip0aiiUZkgnr9g==",
+            "version": "9.15.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.15.0.tgz",
+            "integrity": "sha512-7CrWySmIibCgT1Os28lUU6upBshZ+GxybLOrmRzi08kS8MBuO8QA7pXEgYgY5W8vK3e74xv0lpjo9DbaGU9Rkw==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
-                "@eslint/config-array": "^0.18.0",
-                "@eslint/core": "^0.7.0",
-                "@eslint/eslintrc": "^3.1.0",
-                "@eslint/js": "9.14.0",
-                "@eslint/plugin-kit": "^0.2.0",
+                "@eslint/config-array": "^0.19.0",
+                "@eslint/core": "^0.9.0",
+                "@eslint/eslintrc": "^3.2.0",
+                "@eslint/js": "9.15.0",
+                "@eslint/plugin-kit": "^0.2.3",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
-                "@humanwhocodes/retry": "^0.4.0",
+                "@humanwhocodes/retry": "^0.4.1",
                 "@types/estree": "^1.0.6",
                 "@types/json-schema": "^7.0.15",
                 "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
-                "cross-spawn": "^7.0.2",
+                "cross-spawn": "^7.0.5",
                 "debug": "^4.3.2",
                 "escape-string-regexp": "^4.0.0",
                 "eslint-scope": "^8.2.0",
@@ -5964,8 +5972,7 @@
                 "lodash.merge": "^4.6.2",
                 "minimatch": "^3.1.2",
                 "natural-compare": "^1.4.0",
-                "optionator": "^0.9.3",
-                "text-table": "^0.2.0"
+                "optionator": "^0.9.3"
             },
             "bin": {
                 "eslint": "bin/eslint.js"
@@ -6210,7 +6217,6 @@
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
             "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
@@ -6227,7 +6233,6 @@
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "is-glob": "^4.0.1"
             },
@@ -6262,7 +6267,6 @@
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
             "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "reusify": "^1.0.4"
             }
@@ -6316,7 +6320,6 @@
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -7124,7 +7127,6 @@
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
             }
@@ -7678,7 +7680,6 @@
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 8"
             }
@@ -7782,7 +7783,6 @@
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
             "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
@@ -7823,7 +7823,6 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
             "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
@@ -8387,8 +8386,7 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ],
-            "license": "MIT"
+            ]
         },
         "node_modules/randombytes": {
             "version": "2.1.0",
@@ -8581,7 +8579,6 @@
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
             "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
@@ -8649,7 +8646,6 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
                 "queue-microtask": "^1.2.2"
             }
@@ -9243,12 +9239,6 @@
             "license": "MIT",
             "peer": true
         },
-        "node_modules/text-table": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-            "dev": true
-        },
         "node_modules/tiny-inflate": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
@@ -9320,7 +9310,6 @@
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "is-number": "^7.0.0"
             },
@@ -9501,15 +9490,14 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.14.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.14.0.tgz",
-            "integrity": "sha512-K8fBJHxVL3kxMmwByvz8hNdBJ8a0YqKzKDX6jRlrjMuNXyd5T2V02HIq37+OiWXvUUOXgOOGiSSOh26Mh8pC3w==",
+            "version": "8.15.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.15.0.tgz",
+            "integrity": "sha512-wY4FRGl0ZI+ZU4Jo/yjdBu0lVTSML58pu6PgGtJmCufvzfV565pUF6iACQt092uFOd49iLOTX/sEVmHtbSrS+w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.14.0",
-                "@typescript-eslint/parser": "8.14.0",
-                "@typescript-eslint/utils": "8.14.0"
+                "@typescript-eslint/eslint-plugin": "8.15.0",
+                "@typescript-eslint/parser": "8.15.0",
+                "@typescript-eslint/utils": "8.15.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -9517,6 +9505,9 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0"
             },
             "peerDependenciesMeta": {
                 "typescript": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,37 +21,34 @@
             }
         },
         "node_modules/@algolia/autocomplete-core": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz",
-            "integrity": "sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==",
+            "version": "1.17.7",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+            "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@algolia/autocomplete-plugin-algolia-insights": "1.9.3",
-                "@algolia/autocomplete-shared": "1.9.3"
+                "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+                "@algolia/autocomplete-shared": "1.17.7"
             }
         },
         "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.3.tgz",
-            "integrity": "sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==",
+            "version": "1.17.7",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+            "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@algolia/autocomplete-shared": "1.9.3"
+                "@algolia/autocomplete-shared": "1.17.7"
             },
             "peerDependencies": {
                 "search-insights": ">= 1 < 3"
             }
         },
         "node_modules/@algolia/autocomplete-preset-algolia": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.9.3.tgz",
-            "integrity": "sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==",
+            "version": "1.17.7",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+            "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@algolia/autocomplete-shared": "1.9.3"
+                "@algolia/autocomplete-shared": "1.17.7"
             },
             "peerDependencies": {
                 "@algolia/client-search": ">= 4.9.1 < 6",
@@ -59,304 +56,193 @@
             }
         },
         "node_modules/@algolia/autocomplete-shared": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.3.tgz",
-            "integrity": "sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==",
+            "version": "1.17.7",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+            "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
             "dev": true,
-            "license": "MIT",
             "peerDependencies": {
                 "@algolia/client-search": ">= 4.9.1 < 6",
                 "algoliasearch": ">= 4.9.1 < 6"
             }
         },
-        "node_modules/@algolia/cache-browser-local-storage": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.24.0.tgz",
-            "integrity": "sha512-t63W9BnoXVrGy9iYHBgObNXqYXM3tYXCjDSHeNwnsc324r4o5UiVKUiAB4THQ5z9U5hTj6qUvwg/Ez43ZD85ww==",
+        "node_modules/@algolia/client-abtesting": {
+            "version": "5.15.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.15.0.tgz",
+            "integrity": "sha512-FaEM40iuiv1mAipYyiptP4EyxkJ8qHfowCpEeusdHUC4C7spATJYArD2rX3AxkVeREkDIgYEOuXcwKUbDCr7Nw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@algolia/cache-common": "4.24.0"
-            }
-        },
-        "node_modules/@algolia/cache-common": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.24.0.tgz",
-            "integrity": "sha512-emi+v+DmVLpMGhp0V9q9h5CdkURsNmFC+cOS6uK9ndeJm9J4TiqSvPYVu+THUP8P/S08rxf5x2P+p3CfID0Y4g==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@algolia/cache-in-memory": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.24.0.tgz",
-            "integrity": "sha512-gDrt2so19jW26jY3/MkFg5mEypFIPbPoXsQGQWAi6TrCPsNOSEYepBMPlucqWigsmEy/prp5ug2jy/N3PVG/8w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/cache-common": "4.24.0"
-            }
-        },
-        "node_modules/@algolia/client-account": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.24.0.tgz",
-            "integrity": "sha512-adcvyJ3KjPZFDybxlqnf+5KgxJtBjwTPTeyG2aOyoJvx0Y8dUQAEOEVOJ/GBxX0WWNbmaSrhDURMhc+QeevDsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "4.24.0",
-                "@algolia/client-search": "4.24.0",
-                "@algolia/transporter": "4.24.0"
-            }
-        },
-        "node_modules/@algolia/client-account/node_modules/@algolia/client-common": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
-            "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/transporter": "4.24.0"
-            }
-        },
-        "node_modules/@algolia/client-account/node_modules/@algolia/client-search": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
-            "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "4.24.0",
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/transporter": "4.24.0"
+                "@algolia/client-common": "5.15.0",
+                "@algolia/requester-browser-xhr": "5.15.0",
+                "@algolia/requester-fetch": "5.15.0",
+                "@algolia/requester-node-http": "5.15.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-analytics": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.24.0.tgz",
-            "integrity": "sha512-y8jOZt1OjwWU4N2qr8G4AxXAzaa8DBvyHTWlHzX/7Me1LX8OayfgHexqrsL4vSBcoMmVw2XnVW9MhL+Y2ZDJXg==",
+            "version": "5.15.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.15.0.tgz",
+            "integrity": "sha512-lho0gTFsQDIdCwyUKTtMuf9nCLwq9jOGlLGIeQGKDxXF7HbiAysFIu5QW/iQr1LzMgDyM9NH7K98KY+BiIFriQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "4.24.0",
-                "@algolia/client-search": "4.24.0",
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/transporter": "4.24.0"
-            }
-        },
-        "node_modules/@algolia/client-analytics/node_modules/@algolia/client-common": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
-            "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/transporter": "4.24.0"
-            }
-        },
-        "node_modules/@algolia/client-analytics/node_modules/@algolia/client-search": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
-            "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "4.24.0",
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/transporter": "4.24.0"
+                "@algolia/client-common": "5.15.0",
+                "@algolia/requester-browser-xhr": "5.15.0",
+                "@algolia/requester-fetch": "5.15.0",
+                "@algolia/requester-node-http": "5.15.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-common": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.7.0.tgz",
-            "integrity": "sha512-hrYlN9yNQukmNj8bBlw9PCXi9jmRQqNUXaG6MXH1aDabjO6YD1WPVqTvaELbIBgTbDJzCn0R2owms0uaxQkjUg==",
+            "version": "5.15.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.15.0.tgz",
+            "integrity": "sha512-IofrVh213VLsDkPoSKMeM9Dshrv28jhDlBDLRcVJQvlL8pzue7PEB1EZ4UoJFYS3NSn7JOcJ/V+olRQzXlJj1w==",
             "dev": true,
-            "license": "MIT",
-            "peer": true,
+            "engines": {
+                "node": ">= 14.0.0"
+            }
+        },
+        "node_modules/@algolia/client-insights": {
+            "version": "5.15.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.15.0.tgz",
+            "integrity": "sha512-bDDEQGfFidDi0UQUCbxXOCdphbVAgbVmxvaV75cypBTQkJ+ABx/Npw7LkFGw1FsoVrttlrrQbwjvUB6mLVKs/w==",
+            "dev": true,
+            "dependencies": {
+                "@algolia/client-common": "5.15.0",
+                "@algolia/requester-browser-xhr": "5.15.0",
+                "@algolia/requester-fetch": "5.15.0",
+                "@algolia/requester-node-http": "5.15.0"
+            },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-personalization": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.24.0.tgz",
-            "integrity": "sha512-l5FRFm/yngztweU0HdUzz1rC4yoWCFo3IF+dVIVTfEPg906eZg5BOd1k0K6rZx5JzyyoP4LdmOikfkfGsKVE9w==",
+            "version": "5.15.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.15.0.tgz",
+            "integrity": "sha512-LfaZqLUWxdYFq44QrasCDED5bSYOswpQjSiIL7Q5fYlefAAUO95PzBPKCfUhSwhb4rKxigHfDkd81AvEicIEoA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "4.24.0",
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/transporter": "4.24.0"
+                "@algolia/client-common": "5.15.0",
+                "@algolia/requester-browser-xhr": "5.15.0",
+                "@algolia/requester-fetch": "5.15.0",
+                "@algolia/requester-node-http": "5.15.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
-        "node_modules/@algolia/client-personalization/node_modules/@algolia/client-common": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
-            "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
+        "node_modules/@algolia/client-query-suggestions": {
+            "version": "5.15.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.15.0.tgz",
+            "integrity": "sha512-wu8GVluiZ5+il8WIRsGKu8VxMK9dAlr225h878GGtpTL6VBvwyJvAyLdZsfFIpY0iN++jiNb31q2C1PlPL+n/A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/transporter": "4.24.0"
+                "@algolia/client-common": "5.15.0",
+                "@algolia/requester-browser-xhr": "5.15.0",
+                "@algolia/requester-fetch": "5.15.0",
+                "@algolia/requester-node-http": "5.15.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-search": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.7.0.tgz",
-            "integrity": "sha512-0Frfjt4oxvVP2qsTQAjwdaG5SvJ3TbHBkBrS6M7cG5RDrgHqOrhBnBGCFT+YO3CeNK54r+d57oB1VcD2F1lHuQ==",
+            "version": "5.15.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.15.0.tgz",
+            "integrity": "sha512-Z32gEMrRRpEta5UqVQA612sLdoqY3AovvUPClDfMxYrbdDAebmGDVPtSogUba1FZ4pP5dx20D3OV3reogLKsRA==",
             "dev": true,
-            "license": "MIT",
-            "peer": true,
             "dependencies": {
-                "@algolia/client-common": "5.7.0",
-                "@algolia/requester-browser-xhr": "5.7.0",
-                "@algolia/requester-fetch": "5.7.0",
-                "@algolia/requester-node-http": "5.7.0"
+                "@algolia/client-common": "5.15.0",
+                "@algolia/requester-browser-xhr": "5.15.0",
+                "@algolia/requester-fetch": "5.15.0",
+                "@algolia/requester-node-http": "5.15.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
-        "node_modules/@algolia/logger-common": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.24.0.tgz",
-            "integrity": "sha512-LLUNjkahj9KtKYrQhFKCzMx0BY3RnNP4FEtO+sBybCjJ73E8jNdaKJ/Dd8A/VA4imVHP5tADZ8pn5B8Ga/wTMA==",
+        "node_modules/@algolia/ingestion": {
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.15.0.tgz",
+            "integrity": "sha512-MkqkAxBQxtQ5if/EX2IPqFA7LothghVyvPoRNA/meS2AW2qkHwcxjuiBxv4H6mnAVEPfJlhu9rkdVz9LgCBgJg==",
             "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@algolia/logger-console": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.24.0.tgz",
-            "integrity": "sha512-X4C8IoHgHfiUROfoRCV+lzSy+LHMgkoEEU1BbKcsfnV0i0S20zyy0NLww9dwVHUWNfPPxdMU+/wKmLGYf96yTg==",
-            "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@algolia/logger-common": "4.24.0"
+                "@algolia/client-common": "5.15.0",
+                "@algolia/requester-browser-xhr": "5.15.0",
+                "@algolia/requester-fetch": "5.15.0",
+                "@algolia/requester-node-http": "5.15.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
+            }
+        },
+        "node_modules/@algolia/monitoring": {
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.15.0.tgz",
+            "integrity": "sha512-QPrFnnGLMMdRa8t/4bs7XilPYnoUXDY8PMQJ1sf9ZFwhUysYYhQNX34/enoO0LBjpoOY6rLpha39YQEFbzgKyQ==",
+            "dev": true,
+            "dependencies": {
+                "@algolia/client-common": "5.15.0",
+                "@algolia/requester-browser-xhr": "5.15.0",
+                "@algolia/requester-fetch": "5.15.0",
+                "@algolia/requester-node-http": "5.15.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/recommend": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-4.24.0.tgz",
-            "integrity": "sha512-P9kcgerfVBpfYHDfVZDvvdJv0lEoCvzNlOy2nykyt5bK8TyieYyiD0lguIJdRZZYGre03WIAFf14pgE+V+IBlw==",
+            "version": "5.15.0",
+            "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.15.0.tgz",
+            "integrity": "sha512-5eupMwSqMLDObgSMF0XG958zR6GJP3f7jHDQ3/WlzCM9/YIJiWIUoJFGsko9GYsA5xbLDHE/PhWtq4chcCdaGQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@algolia/cache-browser-local-storage": "4.24.0",
-                "@algolia/cache-common": "4.24.0",
-                "@algolia/cache-in-memory": "4.24.0",
-                "@algolia/client-common": "4.24.0",
-                "@algolia/client-search": "4.24.0",
-                "@algolia/logger-common": "4.24.0",
-                "@algolia/logger-console": "4.24.0",
-                "@algolia/requester-browser-xhr": "4.24.0",
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/requester-node-http": "4.24.0",
-                "@algolia/transporter": "4.24.0"
-            }
-        },
-        "node_modules/@algolia/recommend/node_modules/@algolia/client-common": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
-            "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/transporter": "4.24.0"
-            }
-        },
-        "node_modules/@algolia/recommend/node_modules/@algolia/client-search": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
-            "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "4.24.0",
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/transporter": "4.24.0"
-            }
-        },
-        "node_modules/@algolia/recommend/node_modules/@algolia/requester-browser-xhr": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.24.0.tgz",
-            "integrity": "sha512-Z2NxZMb6+nVXSjF13YpjYTdvV3032YTBSGm2vnYvYPA6mMxzM3v5rsCiSspndn9rzIW4Qp1lPHBvuoKJV6jnAA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/requester-common": "4.24.0"
-            }
-        },
-        "node_modules/@algolia/recommend/node_modules/@algolia/requester-node-http": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.24.0.tgz",
-            "integrity": "sha512-JF18yTjNOVYvU/L3UosRcvbPMGT9B+/GQWNWnenIImglzNVGpyzChkXLnrSf6uxwVNO6ESGu6oN8MqcGQcjQJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/requester-common": "4.24.0"
-            }
-        },
-        "node_modules/@algolia/requester-browser-xhr": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.7.0.tgz",
-            "integrity": "sha512-ohtIp+lyTGM3agrHyedC3w7ijfdUvSN6wmGuKqUezrNzd0nCkFoLW0OINlyv1ODrTEVnL8PAM/Zqubjafxd/Ww==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@algolia/client-common": "5.7.0"
+                "@algolia/client-common": "5.15.0",
+                "@algolia/requester-browser-xhr": "5.15.0",
+                "@algolia/requester-fetch": "5.15.0",
+                "@algolia/requester-node-http": "5.15.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
-        "node_modules/@algolia/requester-common": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.24.0.tgz",
-            "integrity": "sha512-k3CXJ2OVnvgE3HMwcojpvY6d9kgKMPRxs/kVohrwF5WMr2fnqojnycZkxPoEg+bXm8fi5BBfFmOqgYztRtHsQA==",
+        "node_modules/@algolia/requester-browser-xhr": {
+            "version": "5.15.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.15.0.tgz",
+            "integrity": "sha512-Po/GNib6QKruC3XE+WKP1HwVSfCDaZcXu48kD+gwmtDlqHWKc7Bq9lrS0sNZ456rfCKhXksOmMfUs4wRM/Y96w==",
             "dev": true,
-            "license": "MIT"
+            "dependencies": {
+                "@algolia/client-common": "5.15.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
+            }
         },
         "node_modules/@algolia/requester-fetch": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.7.0.tgz",
-            "integrity": "sha512-Eg8cBhNg2QNnDDldyK77aXvg3wIc5qnpCDCAJXQ2oaqZwwvvYaTgnP1ofznNG6+klri4Fk1YAaC9wyDBhByWIA==",
+            "version": "5.15.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.15.0.tgz",
+            "integrity": "sha512-rOZ+c0P7ajmccAvpeeNrUmEKoliYFL8aOR5qGW5pFq3oj3Iept7Y5mEtEsOBYsRt6qLnaXn4zUKf+N8nvJpcIw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true,
             "dependencies": {
-                "@algolia/client-common": "5.7.0"
+                "@algolia/client-common": "5.15.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/requester-node-http": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.7.0.tgz",
-            "integrity": "sha512-8BDssYEkcp1co06KtHO9b37H+5zVM/h+5kyesJb2C2EHFO3kgzLHWl/JyXOVtYlKQBkmdObYOI0s6JaXRy2yQA==",
+            "version": "5.15.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.15.0.tgz",
+            "integrity": "sha512-b1jTpbFf9LnQHEJP5ddDJKE2sAlhYd7EVSOWgzo/27n/SfCoHfqD0VWntnWYD83PnOKvfe8auZ2+xCb0TXotrQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true,
             "dependencies": {
-                "@algolia/client-common": "5.7.0"
+                "@algolia/client-common": "5.15.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@algolia/transporter": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.24.0.tgz",
-            "integrity": "sha512-86nI7w6NzWxd1Zp9q3413dRshDqAzSbsQjhcDhPIatEFiZrL1/TjnHL8S7jVKFePlIMzDsZWXAXwXzcok9c5oA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/cache-common": "4.24.0",
-                "@algolia/logger-common": "4.24.0",
-                "@algolia/requester-common": "4.24.0"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -364,7 +250,6 @@
             "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
             "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
             "dev": true,
-            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
@@ -375,14 +260,14 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.25.7.tgz",
-            "integrity": "sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==",
+            "version": "7.26.2",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+            "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/highlight": "^7.25.7",
+                "@babel/helper-validator-identifier": "^7.25.9",
+                "js-tokens": "^4.0.0",
                 "picocolors": "^1.0.0"
             },
             "engines": {
@@ -390,34 +275,32 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.7.tgz",
-            "integrity": "sha512-9ickoLz+hcXCeh7jrcin+/SLWm+GkxE2kTvoYyp38p4WkdFXfQJxDFGWp/YHjiKLPx06z2A7W8XKuqbReXDzsw==",
+            "version": "7.26.2",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.2.tgz",
+            "integrity": "sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.7.tgz",
-            "integrity": "sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow==",
+            "version": "7.26.0",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
+            "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.25.7",
-                "@babel/generator": "^7.25.7",
-                "@babel/helper-compilation-targets": "^7.25.7",
-                "@babel/helper-module-transforms": "^7.25.7",
-                "@babel/helpers": "^7.25.7",
-                "@babel/parser": "^7.25.7",
-                "@babel/template": "^7.25.7",
-                "@babel/traverse": "^7.25.7",
-                "@babel/types": "^7.25.7",
+                "@babel/code-frame": "^7.26.0",
+                "@babel/generator": "^7.26.0",
+                "@babel/helper-compilation-targets": "^7.25.9",
+                "@babel/helper-module-transforms": "^7.26.0",
+                "@babel/helpers": "^7.26.0",
+                "@babel/parser": "^7.26.0",
+                "@babel/template": "^7.25.9",
+                "@babel/traverse": "^7.25.9",
+                "@babel/types": "^7.26.0",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -437,21 +320,20 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
-            "license": "ISC",
             "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.7.tgz",
-            "integrity": "sha512-5Dqpl5fyV9pIAD62yK9P7fcA768uVPUyrQmqpqstHWgMma4feF1x/oFysBCVZLY5wJ2GkMUCdsNDnGZrPoR6rA==",
+            "version": "7.26.2",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.2.tgz",
+            "integrity": "sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/types": "^7.25.7",
+                "@babel/parser": "^7.26.2",
+                "@babel/types": "^7.26.0",
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "jsesc": "^3.0.2"
@@ -461,44 +343,41 @@
             }
         },
         "node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.7.tgz",
-            "integrity": "sha512-4xwU8StnqnlIhhioZf1tqnVWeQ9pvH/ujS8hRfw/WOza+/a+1qv69BWNy+oY231maTCWgKWhfBU7kDpsds6zAA==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz",
+            "integrity": "sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/types": "^7.25.7"
+                "@babel/types": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-builder-binary-assignment-operator-visitor": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.25.7.tgz",
-            "integrity": "sha512-12xfNeKNH7jubQNm7PAkzlLwEmCs1tfuX3UjIw6vP6QXi+leKh6+LyC/+Ed4EIQermwd58wsyh070yjDHFlNGg==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.25.9.tgz",
+            "integrity": "sha512-C47lC7LIDCnz0h4vai/tpNOI95tCd5ZT3iBt/DBH5lXKHZsyNQv18yf1wIIg2ntiQNgmAvA+DgZ82iW8Qdym8g==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/traverse": "^7.25.7",
-                "@babel/types": "^7.25.7"
+                "@babel/traverse": "^7.25.9",
+                "@babel/types": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.7.tgz",
-            "integrity": "sha512-DniTEax0sv6isaw6qSQSfV4gVRNtw2rte8HHM45t9ZR0xILaufBRNkpMifCRiAPyvL4ACD6v0gfCwCmtOQaV4A==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
+            "integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/compat-data": "^7.25.7",
-                "@babel/helper-validator-option": "^7.25.7",
+                "@babel/compat-data": "^7.25.9",
+                "@babel/helper-validator-option": "^7.25.9",
                 "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
@@ -512,26 +391,24 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
-            "license": "ISC",
             "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
         },
         "node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.7.tgz",
-            "integrity": "sha512-bD4WQhbkx80mAyj/WCm4ZHcF4rDxkoLFO6ph8/5/mQ3z4vAzltQXAmbc7GvVJx5H+lk5Mi5EmbTeox5nMGCsbw==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.9.tgz",
+            "integrity": "sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.25.7",
-                "@babel/helper-member-expression-to-functions": "^7.25.7",
-                "@babel/helper-optimise-call-expression": "^7.25.7",
-                "@babel/helper-replace-supers": "^7.25.7",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.25.7",
-                "@babel/traverse": "^7.25.7",
+                "@babel/helper-annotate-as-pure": "^7.25.9",
+                "@babel/helper-member-expression-to-functions": "^7.25.9",
+                "@babel/helper-optimise-call-expression": "^7.25.9",
+                "@babel/helper-replace-supers": "^7.25.9",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
+                "@babel/traverse": "^7.25.9",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -546,21 +423,19 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
-            "license": "ISC",
             "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
         },
         "node_modules/@babel/helper-create-regexp-features-plugin": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.25.7.tgz",
-            "integrity": "sha512-byHhumTj/X47wJ6C6eLpK7wW/WBEcnUeb7D0FNc/jFQnQVw7DOso3Zz5u9x/zLrFVkHa89ZGDbkAa1D54NdrCQ==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.25.9.tgz",
+            "integrity": "sha512-ORPNZ3h6ZRkOyAa/SaHU+XsLZr0UQzRwuDQ0cczIA17nAzZ+85G5cVkOJIj7QavLZGSe8QXUmNFxSZzjcZF9bw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.25.7",
+                "@babel/helper-annotate-as-pure": "^7.25.9",
                 "regexpu-core": "^6.1.1",
                 "semver": "^6.3.1"
             },
@@ -576,18 +451,16 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
-            "license": "ISC",
             "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
         },
         "node_modules/@babel/helper-define-polyfill-provider": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.2.tgz",
-            "integrity": "sha512-LV76g+C502biUK6AyZ3LK10vDpDyCzZnhZFXkH1L75zHPj68+qc8Zfpx2th+gzwA2MzyK+1g/3EPl62yFnVttQ==",
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.3.tgz",
+            "integrity": "sha512-HK7Bi+Hj6H+VTHA3ZvBis7V/6hu9QuTrnMXNybfUf2iiuU/N97I8VjB+KbhFF8Rld/Lx5MzoCwPCpPjfK+n8Cg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@babel/helper-compilation-targets": "^7.22.6",
@@ -601,47 +474,43 @@
             }
         },
         "node_modules/@babel/helper-member-expression-to-functions": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.7.tgz",
-            "integrity": "sha512-O31Ssjd5K6lPbTX9AAYpSKrZmLeagt9uwschJd+Ixo6QiRyfpvgtVQp8qrDR9UNFjZ8+DO34ZkdrN+BnPXemeA==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz",
+            "integrity": "sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/traverse": "^7.25.7",
-                "@babel/types": "^7.25.7"
+                "@babel/traverse": "^7.25.9",
+                "@babel/types": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.7.tgz",
-            "integrity": "sha512-o0xCgpNmRohmnoWKQ0Ij8IdddjyBFE4T2kagL/x6M3+4zUgc+4qTOUBoNe4XxDskt1HPKO007ZPiMgLDq2s7Kw==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
+            "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/traverse": "^7.25.7",
-                "@babel/types": "^7.25.7"
+                "@babel/traverse": "^7.25.9",
+                "@babel/types": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.7.tgz",
-            "integrity": "sha512-k/6f8dKG3yDz/qCwSM+RKovjMix563SLxQFo0UhRNo239SP6n9u5/eLtKD6EAjwta2JHJ49CsD8pms2HdNiMMQ==",
+            "version": "7.26.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
+            "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-module-imports": "^7.25.7",
-                "@babel/helper-simple-access": "^7.25.7",
-                "@babel/helper-validator-identifier": "^7.25.7",
-                "@babel/traverse": "^7.25.7"
+                "@babel/helper-module-imports": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.25.9",
+                "@babel/traverse": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -651,41 +520,38 @@
             }
         },
         "node_modules/@babel/helper-optimise-call-expression": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.7.tgz",
-            "integrity": "sha512-VAwcwuYhv/AT+Vfr28c9y6SHzTan1ryqrydSTFGjU0uDJHw3uZ+PduI8plCLkRsDnqK2DMEDmwrOQRsK/Ykjng==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.9.tgz",
+            "integrity": "sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/types": "^7.25.7"
+                "@babel/types": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.7.tgz",
-            "integrity": "sha512-eaPZai0PiqCi09pPs3pAFfl/zYgGaE6IdXtYvmf0qlcDTd3WCtO7JWCcRd64e0EQrcYgiHibEZnOGsSY4QSgaw==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.9.tgz",
+            "integrity": "sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-remap-async-to-generator": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.25.7.tgz",
-            "integrity": "sha512-kRGE89hLnPfcz6fTrlNU+uhgcwv0mBE4Gv3P9Ke9kLVJYpi4AMVVEElXvB5CabrPZW4nCM8P8UyyjrzCM0O2sw==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.25.9.tgz",
+            "integrity": "sha512-IZtukuUeBbhgOcaW2s06OXTzVNJR0ybm4W5xC1opWFFJMZbwRj5LCk+ByYH7WdZPZTt8KnFwA8pvjN2yqcPlgw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.25.7",
-                "@babel/helper-wrap-function": "^7.25.7",
-                "@babel/traverse": "^7.25.7"
+                "@babel/helper-annotate-as-pure": "^7.25.9",
+                "@babel/helper-wrap-function": "^7.25.9",
+                "@babel/traverse": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -695,16 +561,15 @@
             }
         },
         "node_modules/@babel/helper-replace-supers": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.7.tgz",
-            "integrity": "sha512-iy8JhqlUW9PtZkd4pHM96v6BdJ66Ba9yWSE4z0W4TvSZwLBPkyDsiIU3ENe4SmrzRBs76F7rQXTy1lYC49n6Lw==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.9.tgz",
+            "integrity": "sha512-IiDqTOTBQy0sWyeXyGSC5TBJpGFXBkRynjBeXsvbhQFKj2viwJC76Epz35YLU1fpe/Am6Vppb7W7zM4fPQzLsQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-member-expression-to-functions": "^7.25.7",
-                "@babel/helper-optimise-call-expression": "^7.25.7",
-                "@babel/traverse": "^7.25.7"
+                "@babel/helper-member-expression-to-functions": "^7.25.9",
+                "@babel/helper-optimise-call-expression": "^7.25.9",
+                "@babel/traverse": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -714,204 +579,94 @@
             }
         },
         "node_modules/@babel/helper-simple-access": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.25.7.tgz",
-            "integrity": "sha512-FPGAkJmyoChQeM+ruBGIDyrT2tKfZJO8NcxdC+CWNJi7N8/rZpSxK7yvBJ5O/nF1gfu5KzN7VKG3YVSLFfRSxQ==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.25.9.tgz",
+            "integrity": "sha512-c6WHXuiaRsJTyHYLJV75t9IqsmTbItYfdj99PnzYGQZkYKvan5/2jKJ7gu31J3/BJ/A18grImSPModuyG/Eo0Q==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/traverse": "^7.25.7",
-                "@babel/types": "^7.25.7"
+                "@babel/traverse": "^7.25.9",
+                "@babel/types": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.7.tgz",
-            "integrity": "sha512-pPbNbchZBkPMD50K0p3JGcFMNLVUCuU/ABybm/PGNj4JiHrpmNyqqCphBk4i19xXtNV0JhldQJJtbSW5aUvbyA==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.9.tgz",
+            "integrity": "sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/traverse": "^7.25.7",
-                "@babel/types": "^7.25.7"
+                "@babel/traverse": "^7.25.9",
+                "@babel/types": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.7.tgz",
-            "integrity": "sha512-CbkjYdsJNHFk8uqpEkpCvRs3YRp9tY6FmFY7wLMSYuGYkrdUi7r2lc4/wqsvlHoMznX3WJ9IP8giGPq68T/Y6g==",
-            "license": "MIT",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+            "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.7.tgz",
-            "integrity": "sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==",
-            "license": "MIT",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+            "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.7.tgz",
-            "integrity": "sha512-ytbPLsm+GjArDYXJ8Ydr1c/KJuutjF2besPNbIZnZ6MKUxi/uTA22t2ymmA4WFjZFpjiAMO0xuuJPqK2nvDVfQ==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
+            "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-wrap-function": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.25.7.tgz",
-            "integrity": "sha512-MA0roW3JF2bD1ptAaJnvcabsVlNQShUaThyJbCDD4bCp8NEgiFvpoqRI2YS22hHlc2thjO/fTg2ShLMC3jygAg==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.25.9.tgz",
+            "integrity": "sha512-ETzz9UTjQSTmw39GboatdymDq4XIQbR8ySgVrylRhPOFpsd+JrKHIuF0de7GCWmem+T4uC5z7EZguod7Wj4A4g==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/template": "^7.25.7",
-                "@babel/traverse": "^7.25.7",
-                "@babel/types": "^7.25.7"
+                "@babel/template": "^7.25.9",
+                "@babel/traverse": "^7.25.9",
+                "@babel/types": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.7.tgz",
-            "integrity": "sha512-Sv6pASx7Esm38KQpF/U/OXLwPPrdGHNKoeblRxgZRLXnAtnkEe4ptJPDtAZM7fBLadbc1Q07kQpSiGQ0Jg6tRA==",
+            "version": "7.26.0",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
+            "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/template": "^7.25.7",
-                "@babel/types": "^7.25.7"
+                "@babel/template": "^7.25.9",
+                "@babel/types": "^7.26.0"
             },
             "engines": {
                 "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/highlight": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.7.tgz",
-            "integrity": "sha512-iYyACpW3iW8Fw+ZybQK+drQre+ns/tKpXbNESfrhNnPLIklLbXr7MYJ6gPEd0iETGLOK+SxMjVvKb/ffmk+FEw==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-validator-identifier": "^7.25.7",
-                "chalk": "^2.4.2",
-                "js-tokens": "^4.0.0",
-                "picocolors": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/ansi-styles": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "color-convert": "^1.9.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/chalk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.7.tgz",
-            "integrity": "sha512-aZn7ETtQsjjGG5HruveUK06cU3Hljuhd9Iojm4M8WWv3wLE6OkE5PWbDUkItmMgegmccaITudyuW5RPYrYlgWw==",
-            "license": "MIT",
+            "version": "7.26.2",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
+            "integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
             "dependencies": {
-                "@babel/types": "^7.25.7"
+                "@babel/types": "^7.26.0"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -921,15 +676,14 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.25.7.tgz",
-            "integrity": "sha512-UV9Lg53zyebzD1DwQoT9mzkEKa922LNUp5YkTJ6Uta0RbyXaQNUgcvSt7qIu1PpPzVb6rd10OVNTzkyBGeVmxQ==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.25.9.tgz",
+            "integrity": "sha512-ZkRyVkThtxQ/J6nv3JFYv1RYY+JT5BvU0y3k5bWrmuG4woXypRa4PXmm9RhOwodRkYFWqC0C0cqcJ4OqR7kW+g==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "@babel/traverse": "^7.25.7"
+                "@babel/helper-plugin-utils": "^7.25.9",
+                "@babel/traverse": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -939,14 +693,13 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.25.7.tgz",
-            "integrity": "sha512-GDDWeVLNxRIkQTnJn2pDOM1pkCgYdSqPeT1a9vh9yIqu2uzzgw1zcqEb+IJOhy+dTBMlNdThrDIksr2o09qrrQ==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.25.9.tgz",
+            "integrity": "sha512-MrGRLZxLD/Zjj0gdU15dfs+HH/OXvnw/U4jJD8vpcP2CJQapPEv1IWwjc/qMg7ItBlPwSv1hRBbb7LeuANdcnw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -956,14 +709,13 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.25.7.tgz",
-            "integrity": "sha512-wxyWg2RYaSUYgmd9MR0FyRGyeOMQE/Uzr1wzd/g5cf5bwi9A4v6HFdDm7y1MgDtod/fLOSTZY6jDgV0xU9d5bA==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.25.9.tgz",
+            "integrity": "sha512-2qUwwfAFpJLZqxd02YW9btUCZHl+RFvdDkNfZwaIJrvB8Tesjsk8pEQkTvGwZXLqXUx/2oyY3ySRhm6HOXuCug==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -973,16 +725,15 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.25.7.tgz",
-            "integrity": "sha512-Xwg6tZpLxc4iQjorYsyGMyfJE7nP5MV8t/Ka58BgiA7Jw0fRqQNcANlLfdJ/yvBt9z9LD2We+BEkT7vLqZRWng==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.25.9.tgz",
+            "integrity": "sha512-6xWgLZTJXwilVjlnV7ospI3xi+sl8lN8rXXbBD6vYn3UYDlGsag8wrZkKcSI8G6KgqKP7vNFaDgeDnfAABq61g==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.25.7",
-                "@babel/plugin-transform-optional-chaining": "^7.25.7"
+                "@babel/helper-plugin-utils": "^7.25.9",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
+                "@babel/plugin-transform-optional-chaining": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -992,15 +743,14 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.25.7.tgz",
-            "integrity": "sha512-UVATLMidXrnH+GMUIuxq55nejlj02HP7F5ETyBONzP6G87fPBogG4CH6kxrSrdIuAjdwNO9VzyaYsrZPscWUrw==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.25.9.tgz",
+            "integrity": "sha512-aLnMXYPnzwwqhYSCyXfKkIkYgJ8zv9RK+roo9DkTXz38ynIhd9XCbN08s3MGvqL2MYGVUGdRQLL/JqBIeJhJBg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "@babel/traverse": "^7.25.7"
+                "@babel/helper-plugin-utils": "^7.25.9",
+                "@babel/traverse": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1014,97 +764,22 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
             "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-async-generators": {
-            "version": "7.8.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
-            "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-class-properties": {
-            "version": "7.12.13",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
-            "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.12.13"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-class-static-block": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
-            "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.14.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-dynamic-import": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
-            "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-export-namespace-from": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
-            "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.3"
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0-0"
             }
         },
         "node_modules/@babel/plugin-syntax-import-assertions": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.25.7.tgz",
-            "integrity": "sha512-ZvZQRmME0zfJnDQnVBKYzHxXT7lYBB3Revz1GuS7oLXWMgqUPX4G+DDbT30ICClht9WKV34QVrZhSw6WdklwZQ==",
+            "version": "7.26.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.26.0.tgz",
+            "integrity": "sha512-QCWT5Hh830hK5EQa7XzuqIkQU9tT/whqbDz7kuaZMHFl1inRRg7JnuAEOQ0Ur0QUl0NufCk1msK2BeY79Aj/eg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1114,160 +789,13 @@
             }
         },
         "node_modules/@babel/plugin-syntax-import-attributes": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.25.7.tgz",
-            "integrity": "sha512-AqVo+dguCgmpi/3mYBdu9lkngOBlQ2w2vnNpa6gfiCxQZLzV4ZbhsXitJ2Yblkoe1VQwtHSaNmIaGll/26YWRw==",
+            "version": "7.26.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
+            "integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-import-meta": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
-            "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.10.4"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-json-strings": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
-            "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
-            "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.10.4"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
-            "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-numeric-separator": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
-            "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.10.4"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-object-rest-spread": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
-            "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-optional-catch-binding": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
-            "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-optional-chaining": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
-            "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-private-property-in-object": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
-            "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.14.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-top-level-await": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
-            "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.14.5"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1281,7 +809,6 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
             "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@babel/helper-create-regexp-features-plugin": "^7.18.6",
@@ -1295,14 +822,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-arrow-functions": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.25.7.tgz",
-            "integrity": "sha512-EJN2mKxDwfOUCPxMO6MUI58RN3ganiRAG/MS/S3HfB6QFNjroAMelQo/gybyYq97WerCBAZoyrAoW8Tzdq2jWg==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.25.9.tgz",
+            "integrity": "sha512-6jmooXYIwn9ca5/RylZADJ+EnSxVUS5sjeJ9UPk6RWRzXCmOJCy6dqItPJFpw2cuCangPK4OYr5uhGKcmrm5Qg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1312,17 +838,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-async-generator-functions": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.7.tgz",
-            "integrity": "sha512-4B6OhTrwYKHYYgcwErvZjbmH9X5TxQBsaBHdzEIB4l71gR5jh/tuHGlb9in47udL2+wVUcOz5XXhhfhVJwEpEg==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.9.tgz",
+            "integrity": "sha512-RXV6QAzTBbhDMO9fWwOmwwTuYaiPbggWQ9INdZqAYeSHyG7FzQ+nOZaUUjNwKv9pV3aE4WFqFm1Hnbci5tBCAw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "@babel/helper-remap-async-to-generator": "^7.25.7",
-                "@babel/plugin-syntax-async-generators": "^7.8.4",
-                "@babel/traverse": "^7.25.7"
+                "@babel/helper-plugin-utils": "^7.25.9",
+                "@babel/helper-remap-async-to-generator": "^7.25.9",
+                "@babel/traverse": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1332,16 +856,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-async-to-generator": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.25.7.tgz",
-            "integrity": "sha512-ZUCjAavsh5CESCmi/xCpX1qcCaAglzs/7tmuvoFnJgA1dM7gQplsguljoTg+Ru8WENpX89cQyAtWoaE0I3X3Pg==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.25.9.tgz",
+            "integrity": "sha512-NT7Ejn7Z/LjUH0Gv5KsBCxh7BH3fbLTV0ptHvpeMvrt3cPThHfJfst9Wrb7S8EvJ7vRTFI7z+VAvFVEQn/m5zQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-module-imports": "^7.25.7",
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "@babel/helper-remap-async-to-generator": "^7.25.7"
+                "@babel/helper-module-imports": "^7.25.9",
+                "@babel/helper-plugin-utils": "^7.25.9",
+                "@babel/helper-remap-async-to-generator": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1351,14 +874,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-block-scoped-functions": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.25.7.tgz",
-            "integrity": "sha512-xHttvIM9fvqW+0a3tZlYcZYSBpSWzGBFIt/sYG3tcdSzBB8ZeVgz2gBP7Df+sM0N1850jrviYSSeUuc+135dmQ==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.25.9.tgz",
+            "integrity": "sha512-toHc9fzab0ZfenFpsyYinOX0J/5dgJVA2fm64xPewu7CoYHWEivIWKxkK2rMi4r3yQqLnVmheMXRdG+k239CgA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1368,14 +890,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-block-scoping": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.25.7.tgz",
-            "integrity": "sha512-ZEPJSkVZaeTFG/m2PARwLZQ+OG0vFIhPlKHK/JdIMy8DbRJ/htz6LRrTFtdzxi9EHmcwbNPAKDnadpNSIW+Aow==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.25.9.tgz",
+            "integrity": "sha512-1F05O7AYjymAtqbsFETboN1NvBdcnzMerO+zlMyJBEz6WkMdejvGWw9p05iTSjC85RLlBseHHQpYaM4gzJkBGg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1385,15 +906,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-class-properties": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.25.7.tgz",
-            "integrity": "sha512-mhyfEW4gufjIqYFo9krXHJ3ElbFLIze5IDp+wQTxoPd+mwFb1NxatNAwmv8Q8Iuxv7Zc+q8EkiMQwc9IhyGf4g==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.25.9.tgz",
+            "integrity": "sha512-bbMAII8GRSkcd0h0b4X+36GksxuheLFjP65ul9w6C3KgAamI3JqErNgSrosX6ZPj+Mpim5VvEbawXxJCyEUV3Q==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.25.7",
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-create-class-features-plugin": "^7.25.9",
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1403,16 +923,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-class-static-block": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.25.7.tgz",
-            "integrity": "sha512-rvUUtoVlkDWtDWxGAiiQj0aNktTPn3eFynBcMC2IhsXweehwgdI9ODe+XjWw515kEmv22sSOTp/rxIRuTiB7zg==",
+            "version": "7.26.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.26.0.tgz",
+            "integrity": "sha512-6J2APTs7BDDm+UMqP1useWqhcRAXo0WIoVj26N7kPFB6S73Lgvyka4KTZYIxtgYXiN5HTyRObA72N2iu628iTQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.25.7",
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "@babel/plugin-syntax-class-static-block": "^7.14.5"
+                "@babel/helper-create-class-features-plugin": "^7.25.9",
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1422,18 +940,17 @@
             }
         },
         "node_modules/@babel/plugin-transform-classes": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.7.tgz",
-            "integrity": "sha512-9j9rnl+YCQY0IGoeipXvnk3niWicIB6kCsWRGLwX241qSXpbA4MKxtp/EdvFxsc4zI5vqfLxzOd0twIJ7I99zg==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.9.tgz",
+            "integrity": "sha512-mD8APIXmseE7oZvZgGABDyM34GUmK45Um2TXiBUt7PnuAxrgoSVf123qUzPxEr/+/BHrRn5NMZCdE2m/1F8DGg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.25.7",
-                "@babel/helper-compilation-targets": "^7.25.7",
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "@babel/helper-replace-supers": "^7.25.7",
-                "@babel/traverse": "^7.25.7",
+                "@babel/helper-annotate-as-pure": "^7.25.9",
+                "@babel/helper-compilation-targets": "^7.25.9",
+                "@babel/helper-plugin-utils": "^7.25.9",
+                "@babel/helper-replace-supers": "^7.25.9",
+                "@babel/traverse": "^7.25.9",
                 "globals": "^11.1.0"
             },
             "engines": {
@@ -1448,22 +965,20 @@
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=4"
             }
         },
         "node_modules/@babel/plugin-transform-computed-properties": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.25.7.tgz",
-            "integrity": "sha512-QIv+imtM+EtNxg/XBKL3hiWjgdLjMOmZ+XzQwSgmBfKbfxUjBzGgVPklUuE55eq5/uVoh8gg3dqlrwR/jw3ZeA==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.25.9.tgz",
+            "integrity": "sha512-HnBegGqXZR12xbcTHlJ9HGxw1OniltT26J5YpfruGqtUHlz/xKf/G2ak9e+t0rVqrjXa9WOhvYPz1ERfMj23AA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "@babel/template": "^7.25.7"
+                "@babel/helper-plugin-utils": "^7.25.9",
+                "@babel/template": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1473,14 +988,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-destructuring": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.25.7.tgz",
-            "integrity": "sha512-xKcfLTlJYUczdaM1+epcdh1UGewJqr9zATgrNHcLBcV2QmfvPPEixo/sK/syql9cEmbr7ulu5HMFG5vbbt/sEA==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.25.9.tgz",
+            "integrity": "sha512-WkCGb/3ZxXepmMiX101nnGiU+1CAdut8oHyEOHxkKuS1qKpU2SMXE2uSvfz8PBuLd49V6LEsbtyPhWC7fnkgvQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1490,15 +1004,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-dotall-regex": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.25.7.tgz",
-            "integrity": "sha512-kXzXMMRzAtJdDEgQBLF4oaiT6ZCU3oWHgpARnTKDAqPkDJ+bs3NrZb310YYevR5QlRo3Kn7dzzIdHbZm1VzJdQ==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.25.9.tgz",
+            "integrity": "sha512-t7ZQ7g5trIgSRYhI9pIJtRl64KHotutUJsh4Eze5l7olJv+mRSg4/MmbZ0tv1eeqRbdvo/+trvJD/Oc5DmW2cA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.25.7",
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1508,14 +1021,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-duplicate-keys": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.25.7.tgz",
-            "integrity": "sha512-by+v2CjoL3aMnWDOyCIg+yxU9KXSRa9tN6MbqggH5xvymmr9p4AMjYkNlQy4brMceBnUyHZ9G8RnpvT8wP7Cfg==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.25.9.tgz",
+            "integrity": "sha512-LZxhJ6dvBb/f3x8xwWIuyiAHy56nrRG3PeYTpBkkzkYRRQ6tJLu68lEF5VIqMUZiAV7a8+Tb78nEoMCMcqjXBw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1525,15 +1037,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.25.7.tgz",
-            "integrity": "sha512-HvS6JF66xSS5rNKXLqkk7L9c/jZ/cdIVIcoPVrnl8IsVpLggTjXs8OWekbLHs/VtYDDh5WXnQyeE3PPUGm22MA==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.25.9.tgz",
+            "integrity": "sha512-0UfuJS0EsXbRvKnwcLjFtJy/Sxc5J5jhLHnFhy7u4zih97Hz6tJkLU+O+FMMrNZrosUPxDi6sYxJ/EA8jDiAog==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.25.7",
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1543,15 +1054,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-dynamic-import": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.25.7.tgz",
-            "integrity": "sha512-UvcLuual4h7/GfylKm2IAA3aph9rwvAM2XBA0uPKU3lca+Maai4jBjjEVUS568ld6kJcgbouuumCBhMd/Yz17w==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.25.9.tgz",
+            "integrity": "sha512-GCggjexbmSLaFhqsojeugBpeaRIgWNTcgKVq/0qIteFEqY2A+b9QidYadrWlnbWQUrW5fn+mCvf3tr7OeBFTyg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "@babel/plugin-syntax-dynamic-import": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1561,15 +1070,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-exponentiation-operator": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.25.7.tgz",
-            "integrity": "sha512-yjqtpstPfZ0h/y40fAXRv2snciYr0OAoMXY/0ClC7tm4C/nG5NJKmIItlaYlLbIVAWNfrYuy9dq1bE0SbX0PEg==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.25.9.tgz",
+            "integrity": "sha512-KRhdhlVk2nObA5AYa7QMgTMTVJdfHprfpAk4DjZVtllqRg9qarilstTKEhpVjyt+Npi8ThRyiV8176Am3CodPA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.25.7",
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.25.9",
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1579,15 +1087,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-export-namespace-from": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.25.7.tgz",
-            "integrity": "sha512-h3MDAP5l34NQkkNulsTNyjdaR+OiB0Im67VU//sFupouP8Q6m9Spy7l66DcaAQxtmCqGdanPByLsnwFttxKISQ==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.25.9.tgz",
+            "integrity": "sha512-2NsEz+CxzJIVOPx2o9UsW1rXLqtChtLoVnwYHHiB04wS5sgn7mrV45fWMBX0Kk+ub9uXytVYfNP2HjbVbCB3Ww==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1597,15 +1103,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-for-of": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.25.7.tgz",
-            "integrity": "sha512-n/TaiBGJxYFWvpJDfsxSj9lEEE44BFM1EPGz4KEiTipTgkoFVVcCmzAL3qA7fdQU96dpo4gGf5HBx/KnDvqiHw==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.25.9.tgz",
+            "integrity": "sha512-LqHxduHoaGELJl2uhImHwRQudhCM50pT46rIBNvtT/Oql3nqiS3wOwP+5ten7NpYSXrrVLgtZU3DZmPtWZo16A==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.25.7"
+                "@babel/helper-plugin-utils": "^7.25.9",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1615,16 +1120,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-function-name": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.25.7.tgz",
-            "integrity": "sha512-5MCTNcjCMxQ63Tdu9rxyN6cAWurqfrDZ76qvVPrGYdBxIj+EawuuxTu/+dgJlhK5eRz3v1gLwp6XwS8XaX2NiQ==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.25.9.tgz",
+            "integrity": "sha512-8lP+Yxjv14Vc5MuWBpJsoUCd3hD6V9DgBon2FVYL4jJgbnVQ9fTgYmonchzZJOVNgzEgbxp4OwAf6xz6M/14XA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-compilation-targets": "^7.25.7",
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "@babel/traverse": "^7.25.7"
+                "@babel/helper-compilation-targets": "^7.25.9",
+                "@babel/helper-plugin-utils": "^7.25.9",
+                "@babel/traverse": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1634,15 +1138,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-json-strings": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.25.7.tgz",
-            "integrity": "sha512-Ot43PrL9TEAiCe8C/2erAjXMeVSnE/BLEx6eyrKLNFCCw5jvhTHKyHxdI1pA0kz5njZRYAnMO2KObGqOCRDYSA==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.25.9.tgz",
+            "integrity": "sha512-xoTMk0WXceiiIvsaquQQUaLLXSW1KJ159KP87VilruQm0LNNGxWzahxSS6T6i4Zg3ezp4vA4zuwiNUR53qmQAw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "@babel/plugin-syntax-json-strings": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1652,14 +1154,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-literals": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.25.7.tgz",
-            "integrity": "sha512-fwzkLrSu2fESR/cm4t6vqd7ebNIopz2QHGtjoU+dswQo/P6lwAG04Q98lliE3jkz/XqnbGFLnUcE0q0CVUf92w==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.25.9.tgz",
+            "integrity": "sha512-9N7+2lFziW8W9pBl2TzaNht3+pgMIRP74zizeCSrtnSKVdUl8mAjjOP2OOVQAfZ881P2cNjDj1uAMEdeD50nuQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1669,15 +1170,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-logical-assignment-operators": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.25.7.tgz",
-            "integrity": "sha512-iImzbA55BjiovLyG2bggWS+V+OLkaBorNvc/yJoeeDQGztknRnDdYfp2d/UPmunZYEnZi6Lg8QcTmNMHOB0lGA==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.25.9.tgz",
+            "integrity": "sha512-wI4wRAzGko551Y8eVf6iOY9EouIDTtPb0ByZx+ktDGHwv6bHFimrgJM/2T021txPZ2s4c7bqvHbd+vXG6K948Q==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1687,14 +1186,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-member-expression-literals": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.25.7.tgz",
-            "integrity": "sha512-Std3kXwpXfRV0QtQy5JJcRpkqP8/wG4XL7hSKZmGlxPlDqmpXtEPRmhF7ztnlTCtUN3eXRUJp+sBEZjaIBVYaw==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.25.9.tgz",
+            "integrity": "sha512-PYazBVfofCQkkMzh2P6IdIUaCEWni3iYEerAsRWuVd8+jlM1S9S9cz1dF9hIzyoZ8IA3+OwVYIp9v9e+GbgZhA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1704,15 +1202,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-amd": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.25.7.tgz",
-            "integrity": "sha512-CgselSGCGzjQvKzghCvDTxKHP3iooenLpJDO842ehn5D2G5fJB222ptnDwQho0WjEvg7zyoxb9P+wiYxiJX5yA==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.25.9.tgz",
+            "integrity": "sha512-g5T11tnI36jVClQlMlt4qKDLlWnG5pP9CSM4GhdRciTNMRgkfpo5cR6b4rGIOYPgRRuFAvwjPQ/Yk+ql4dyhbw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.25.7",
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-module-transforms": "^7.25.9",
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1722,16 +1219,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-commonjs": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.25.7.tgz",
-            "integrity": "sha512-L9Gcahi0kKFYXvweO6n0wc3ZG1ChpSFdgG+eV1WYZ3/dGbJK7vvk91FgGgak8YwRgrCuihF8tE/Xg07EkL5COg==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.25.9.tgz",
+            "integrity": "sha512-dwh2Ol1jWwL2MgkCzUSOvfmKElqQcuswAZypBSUsScMXvgdT8Ekq5YA6TtqpTVWH+4903NmboMuH1o9i8Rxlyg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.25.7",
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "@babel/helper-simple-access": "^7.25.7"
+                "@babel/helper-module-transforms": "^7.25.9",
+                "@babel/helper-plugin-utils": "^7.25.9",
+                "@babel/helper-simple-access": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1741,17 +1237,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-systemjs": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.25.7.tgz",
-            "integrity": "sha512-t9jZIvBmOXJsiuyOwhrIGs8dVcD6jDyg2icw1VL4A/g+FnWyJKwUfSSU2nwJuMV2Zqui856El9u+ElB+j9fV1g==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.25.9.tgz",
+            "integrity": "sha512-hyss7iIlH/zLHaehT+xwiymtPOpsiwIIRlCAOwBB04ta5Tt+lNItADdlXw3jAWZ96VJ2jlhl/c+PNIQPKNfvcA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.25.7",
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "@babel/helper-validator-identifier": "^7.25.7",
-                "@babel/traverse": "^7.25.7"
+                "@babel/helper-module-transforms": "^7.25.9",
+                "@babel/helper-plugin-utils": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.25.9",
+                "@babel/traverse": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1761,15 +1256,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-umd": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.25.7.tgz",
-            "integrity": "sha512-p88Jg6QqsaPh+EB7I9GJrIqi1Zt4ZBHUQtjw3z1bzEXcLh6GfPqzZJ6G+G1HBGKUNukT58MnKG7EN7zXQBCODw==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.25.9.tgz",
+            "integrity": "sha512-bS9MVObUgE7ww36HEfwe6g9WakQ0KF07mQF74uuXdkoziUPfKyu/nIm663kz//e5O1nPInPFx36z7WJmJ4yNEw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.25.7",
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-module-transforms": "^7.25.9",
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1779,15 +1273,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.25.7.tgz",
-            "integrity": "sha512-BtAT9LzCISKG3Dsdw5uso4oV1+v2NlVXIIomKJgQybotJY3OwCwJmkongjHgwGKoZXd0qG5UZ12JUlDQ07W6Ow==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.25.9.tgz",
+            "integrity": "sha512-oqB6WHdKTGl3q/ItQhpLSnWWOpjUJLsOCLVyeFgeTktkBSCiurvPOsyt93gibI9CmuKvTUEtWmG5VhZD+5T/KA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.25.7",
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1797,14 +1290,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-new-target": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.25.7.tgz",
-            "integrity": "sha512-CfCS2jDsbcZaVYxRFo2qtavW8SpdzmBXC2LOI4oO0rP+JSRDxxF3inF4GcPsLgfb5FjkhXG5/yR/lxuRs2pySA==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.25.9.tgz",
+            "integrity": "sha512-U/3p8X1yCSoKyUj2eOBIx3FOn6pElFOKvAAGf8HTtItuPyB+ZeOqfn+mvTtg9ZlOAjsPdK3ayQEjqHjU/yLeVQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1814,15 +1306,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.25.7.tgz",
-            "integrity": "sha512-FbuJ63/4LEL32mIxrxwYaqjJxpbzxPVQj5a+Ebrc8JICV6YX8nE53jY+K0RZT3um56GoNWgkS2BQ/uLGTjtwfw==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.25.9.tgz",
+            "integrity": "sha512-ENfftpLZw5EItALAD4WsY/KUWvhUlZndm5GC7G3evUsVeSJB6p0pBeLQUnRnBCBx7zV0RKQjR9kCuwrsIrjWog==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1832,15 +1322,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-numeric-separator": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.25.7.tgz",
-            "integrity": "sha512-8CbutzSSh4hmD+jJHIA8vdTNk15kAzOnFLVVgBSMGr28rt85ouT01/rezMecks9pkU939wDInImwCKv4ahU4IA==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.25.9.tgz",
+            "integrity": "sha512-TlprrJ1GBZ3r6s96Yq8gEQv82s8/5HnCVHtEJScUj90thHQbwe+E5MLhi2bbNHBEJuzrvltXSru+BUxHDoog7Q==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "@babel/plugin-syntax-numeric-separator": "^7.10.4"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1850,17 +1338,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-object-rest-spread": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.25.7.tgz",
-            "integrity": "sha512-1JdVKPhD7Y5PvgfFy0Mv2brdrolzpzSoUq2pr6xsR+m+3viGGeHEokFKsCgOkbeFOQxfB1Vt2F0cPJLRpFI4Zg==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.25.9.tgz",
+            "integrity": "sha512-fSaXafEE9CVHPweLYw4J0emp1t8zYTXyzN3UuG+lylqkvYd7RMrsOQ8TYx5RF231be0vqtFC6jnx3UmpJmKBYg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-compilation-targets": "^7.25.7",
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-                "@babel/plugin-transform-parameters": "^7.25.7"
+                "@babel/helper-compilation-targets": "^7.25.9",
+                "@babel/helper-plugin-utils": "^7.25.9",
+                "@babel/plugin-transform-parameters": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1870,15 +1356,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-object-super": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.25.7.tgz",
-            "integrity": "sha512-pWT6UXCEW3u1t2tcAGtE15ornCBvopHj9Bps9D2DsH15APgNVOTwwczGckX+WkAvBmuoYKRCFa4DK+jM8vh5AA==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.25.9.tgz",
+            "integrity": "sha512-Kj/Gh+Rw2RNLbCK1VAWj2U48yxxqL2x0k10nPtSdRa0O2xnHXalD0s+o1A6a0W43gJ00ANo38jxkQreckOzv5A==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "@babel/helper-replace-supers": "^7.25.7"
+                "@babel/helper-plugin-utils": "^7.25.9",
+                "@babel/helper-replace-supers": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1888,15 +1373,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-optional-catch-binding": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.25.7.tgz",
-            "integrity": "sha512-m9obYBA39mDPN7lJzD5WkGGb0GO54PPLXsbcnj1Hyeu8mSRz7Gb4b1A6zxNX32ZuUySDK4G6it8SDFWD1nCnqg==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.25.9.tgz",
+            "integrity": "sha512-qM/6m6hQZzDcZF3onzIhZeDHDO43bkNNlOX0i8n3lR6zLbu0GN2d8qfM/IERJZYauhAHSLHy39NF0Ctdvcid7g==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1906,16 +1389,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-optional-chaining": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.25.7.tgz",
-            "integrity": "sha512-h39agClImgPWg4H8mYVAbD1qP9vClFbEjqoJmt87Zen8pjqK8FTPUwrOXAvqu5soytwxrLMd2fx2KSCp2CHcNg==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.25.9.tgz",
+            "integrity": "sha512-6AvV0FsLULbpnXeBjrY4dmWF8F7gf8QnvTEoO/wX/5xm/xE1Xo8oPuD3MPS+KS9f9XBEAWN7X1aWr4z9HdOr7A==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.25.7",
-                "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.25.9",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1925,14 +1406,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-parameters": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.25.7.tgz",
-            "integrity": "sha512-FYiTvku63me9+1Nz7TOx4YMtW3tWXzfANZtrzHhUZrz4d47EEtMQhzFoZWESfXuAMMT5mwzD4+y1N8ONAX6lMQ==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.25.9.tgz",
+            "integrity": "sha512-wzz6MKwpnshBAiRmn4jR8LYz/g8Ksg0o80XmwZDlordjwEk9SxBzTWC7F5ef1jhbrbOW2DJ5J6ayRukrJmnr0g==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1942,15 +1422,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-private-methods": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.7.tgz",
-            "integrity": "sha512-KY0hh2FluNxMLwOCHbxVOKfdB5sjWG4M183885FmaqWWiGMhRZq4DQRKH6mHdEucbJnyDyYiZNwNG424RymJjA==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.9.tgz",
+            "integrity": "sha512-D/JUozNpQLAPUVusvqMxyvjzllRaF8/nSrP1s2YGQT/W4LHK4xxsMcHjhOGTS01mp9Hda8nswb+FblLdJornQw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.25.7",
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-create-class-features-plugin": "^7.25.9",
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1960,17 +1439,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-private-property-in-object": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.25.7.tgz",
-            "integrity": "sha512-LzA5ESzBy7tqj00Yjey9yWfs3FKy4EmJyKOSWld144OxkTji81WWnUT8nkLUn+imN/zHL8ZQlOu/MTUAhHaX3g==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.25.9.tgz",
+            "integrity": "sha512-Evf3kcMqzXA3xfYJmZ9Pg1OvKdtqsDMSWBDzZOPLvHiTt36E75jLDQo5w1gtRU95Q4E5PDttrTf25Fw8d/uWLw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.25.7",
-                "@babel/helper-create-class-features-plugin": "^7.25.7",
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+                "@babel/helper-annotate-as-pure": "^7.25.9",
+                "@babel/helper-create-class-features-plugin": "^7.25.9",
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1980,14 +1457,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-property-literals": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.25.7.tgz",
-            "integrity": "sha512-lQEeetGKfFi0wHbt8ClQrUSUMfEeI3MMm74Z73T9/kuz990yYVtfofjf3NuA42Jy3auFOpbjDyCSiIkTs1VIYw==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.25.9.tgz",
+            "integrity": "sha512-IvIUeV5KrS/VPavfSM/Iu+RE6llrHrYIKY1yfCzyO/lMXHQ+p7uGhonmGVisv6tSBSVgWzMBohTcvkC9vQcQFA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1997,14 +1473,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-regenerator": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.25.7.tgz",
-            "integrity": "sha512-mgDoQCRjrY3XK95UuV60tZlFCQGXEtMg8H+IsW72ldw1ih1jZhzYXbJvghmAEpg5UVhhnCeia1CkGttUvCkiMQ==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.25.9.tgz",
+            "integrity": "sha512-vwDcDNsgMPDGP0nMqzahDWE5/MLcX8sv96+wfX7as7LoF/kr97Bo/7fI00lXY4wUXYfVmwIIyG80fGZ1uvt2qg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7",
+                "@babel/helper-plugin-utils": "^7.25.9",
                 "regenerator-transform": "^0.15.2"
             },
             "engines": {
@@ -2014,15 +1489,31 @@
                 "@babel/core": "^7.0.0-0"
             }
         },
-        "node_modules/@babel/plugin-transform-reserved-words": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.25.7.tgz",
-            "integrity": "sha512-3OfyfRRqiGeOvIWSagcwUTVk2hXBsr/ww7bLn6TRTuXnexA+Udov2icFOxFX9abaj4l96ooYkcNN1qi2Zvqwng==",
+        "node_modules/@babel/plugin-transform-regexp-modifiers": {
+            "version": "7.26.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.26.0.tgz",
+            "integrity": "sha512-vN6saax7lrA2yA/Pak3sCxuD6F5InBjn9IcrIKQPjpsLvuHYLVroTxjdlVRHjjBWxKOqIwpTXDkOssYT4BFdRw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+                "@babel/helper-plugin-utils": "^7.25.9"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-reserved-words": {
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.25.9.tgz",
+            "integrity": "sha512-7DL7DKYjn5Su++4RXu8puKZm2XBPHyjWLUidaPEkCUBbE7IPcsrkRHggAOOKydH1dASWdcUBxrkOGNxUv5P3Jg==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2032,14 +1523,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-shorthand-properties": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.25.7.tgz",
-            "integrity": "sha512-uBbxNwimHi5Bv3hUccmOFlUy3ATO6WagTApenHz9KzoIdn0XeACdB12ZJ4cjhuB2WSi80Ez2FWzJnarccriJeA==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.25.9.tgz",
+            "integrity": "sha512-MUv6t0FhO5qHnS/W8XCbHmiRWOphNufpE1IVxhK5kuN3Td9FT1x4rx4K42s3RYdMXCXpfWkGSbCSd0Z64xA7Ng==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2049,15 +1539,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-spread": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.25.7.tgz",
-            "integrity": "sha512-Mm6aeymI0PBh44xNIv/qvo8nmbkpZze1KvR8MkEqbIREDxoiWTi18Zr2jryfRMwDfVZF9foKh060fWgni44luw==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.25.9.tgz",
+            "integrity": "sha512-oNknIB0TbURU5pqJFVbOOFspVlrpVwo2H1+HUIsVDvp5VauGGDP1ZEvO8Nn5xyMEs3dakajOxlmkNW7kNgSm6A==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.25.7"
+                "@babel/helper-plugin-utils": "^7.25.9",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2067,14 +1556,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-sticky-regex": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.25.7.tgz",
-            "integrity": "sha512-ZFAeNkpGuLnAQ/NCsXJ6xik7Id+tHuS+NT+ue/2+rn/31zcdnupCdmunOizEaP0JsUmTFSTOPoQY7PkK2pttXw==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.25.9.tgz",
+            "integrity": "sha512-WqBUSgeVwucYDP9U/xNRQam7xV8W5Zf+6Eo7T2SRVUFlhRiMNFdFz58u0KZmCVVqs2i7SHgpRnAhzRNmKfi2uA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2084,14 +1572,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-template-literals": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.25.7.tgz",
-            "integrity": "sha512-SI274k0nUsFFmyQupiO7+wKATAmMFf8iFgq2O+vVFXZ0SV9lNfT1NGzBEhjquFmD8I9sqHLguH+gZVN3vww2AA==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.25.9.tgz",
+            "integrity": "sha512-o97AE4syN71M/lxrCtQByzphAdlYluKPDBzDVzMmfCobUjjhAryZV0AIpRPrxN0eAkxXO6ZLEScmt+PNhj2OTw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2101,14 +1588,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-typeof-symbol": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.25.7.tgz",
-            "integrity": "sha512-OmWmQtTHnO8RSUbL0NTdtpbZHeNTnm68Gj5pA4Y2blFNh+V4iZR68V1qL9cI37J21ZN7AaCnkfdHtLExQPf2uA==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.25.9.tgz",
+            "integrity": "sha512-v61XqUMiueJROUv66BVIOi0Fv/CUuZuZMl5NkRoCVxLAnMexZ0A3kMe7vvZ0nulxMuMp0Mk6S5hNh48yki08ZA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2118,14 +1604,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-escapes": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.25.7.tgz",
-            "integrity": "sha512-BN87D7KpbdiABA+t3HbVqHzKWUDN3dymLaTnPFAMyc8lV+KN3+YzNhVRNdinaCPA4AUqx7ubXbQ9shRjYBl3SQ==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.25.9.tgz",
+            "integrity": "sha512-s5EDrE6bW97LtxOcGj1Khcx5AaXwiMmi4toFWRDP9/y0Woo6pXC+iyPu/KuhKtfSrNFd7jJB+/fkOtZy6aIC6Q==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2135,15 +1620,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-property-regex": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.25.7.tgz",
-            "integrity": "sha512-IWfR89zcEPQGB/iB408uGtSPlQd3Jpq11Im86vUgcmSTcoWAiQMCTOa2K2yNNqFJEBVICKhayctee65Ka8OB0w==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.25.9.tgz",
+            "integrity": "sha512-Jt2d8Ga+QwRluxRQ307Vlxa6dMrYEMZCgGxoPR8V52rxPyldHu3hdlHspxaqYmE7oID5+kB+UKUB/eWS+DkkWg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.25.7",
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2153,15 +1637,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-regex": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.25.7.tgz",
-            "integrity": "sha512-8JKfg/hiuA3qXnlLx8qtv5HWRbgyFx2hMMtpDDuU2rTckpKkGu4ycK5yYHwuEa16/quXfoxHBIApEsNyMWnt0g==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.25.9.tgz",
+            "integrity": "sha512-yoxstj7Rg9dlNn9UQxzk4fcNivwv4nUYz7fYXBaKxvw/lnmPuOm/ikoELygbYq68Bls3D/D+NBPHiLwZdZZ4HA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.25.7",
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2171,15 +1654,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-sets-regex": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.25.7.tgz",
-            "integrity": "sha512-YRW8o9vzImwmh4Q3Rffd09bH5/hvY0pxg+1H1i0f7APoUeg12G7+HhLj9ZFNIrYkgBXhIijPJ+IXypN0hLTIbw==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.25.9.tgz",
+            "integrity": "sha512-8BYqO3GeVNHtx69fdPshN3fnzUNLrWdHhk/icSwigksJGczKSizZ+Z6SBCxTs723Fr5VSNorTIK7a+R2tISvwQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.25.7",
-                "@babel/helper-plugin-utils": "^7.25.7"
+                "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2189,90 +1671,75 @@
             }
         },
         "node_modules/@babel/preset-env": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.25.7.tgz",
-            "integrity": "sha512-Gibz4OUdyNqqLj+7OAvBZxOD7CklCtMA5/j0JgUEwOnaRULsPDXmic2iKxL2DX2vQduPR5wH2hjZas/Vr/Oc0g==",
+            "version": "7.26.0",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.26.0.tgz",
+            "integrity": "sha512-H84Fxq0CQJNdPFT2DrfnylZ3cf5K43rGfWK4LJGPpjKHiZlk0/RzwEus3PDDZZg+/Er7lCA03MVacueUuXdzfw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/compat-data": "^7.25.7",
-                "@babel/helper-compilation-targets": "^7.25.7",
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "@babel/helper-validator-option": "^7.25.7",
-                "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.25.7",
-                "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.25.7",
-                "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.25.7",
-                "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.25.7",
-                "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.25.7",
+                "@babel/compat-data": "^7.26.0",
+                "@babel/helper-compilation-targets": "^7.25.9",
+                "@babel/helper-plugin-utils": "^7.25.9",
+                "@babel/helper-validator-option": "^7.25.9",
+                "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.25.9",
+                "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.25.9",
+                "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.25.9",
+                "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.25.9",
+                "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.25.9",
                 "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
-                "@babel/plugin-syntax-async-generators": "^7.8.4",
-                "@babel/plugin-syntax-class-properties": "^7.12.13",
-                "@babel/plugin-syntax-class-static-block": "^7.14.5",
-                "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-                "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-                "@babel/plugin-syntax-import-assertions": "^7.25.7",
-                "@babel/plugin-syntax-import-attributes": "^7.25.7",
-                "@babel/plugin-syntax-import-meta": "^7.10.4",
-                "@babel/plugin-syntax-json-strings": "^7.8.3",
-                "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-                "@babel/plugin-syntax-numeric-separator": "^7.10.4",
-                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-                "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-                "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-                "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
-                "@babel/plugin-syntax-top-level-await": "^7.14.5",
+                "@babel/plugin-syntax-import-assertions": "^7.26.0",
+                "@babel/plugin-syntax-import-attributes": "^7.26.0",
                 "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
-                "@babel/plugin-transform-arrow-functions": "^7.25.7",
-                "@babel/plugin-transform-async-generator-functions": "^7.25.7",
-                "@babel/plugin-transform-async-to-generator": "^7.25.7",
-                "@babel/plugin-transform-block-scoped-functions": "^7.25.7",
-                "@babel/plugin-transform-block-scoping": "^7.25.7",
-                "@babel/plugin-transform-class-properties": "^7.25.7",
-                "@babel/plugin-transform-class-static-block": "^7.25.7",
-                "@babel/plugin-transform-classes": "^7.25.7",
-                "@babel/plugin-transform-computed-properties": "^7.25.7",
-                "@babel/plugin-transform-destructuring": "^7.25.7",
-                "@babel/plugin-transform-dotall-regex": "^7.25.7",
-                "@babel/plugin-transform-duplicate-keys": "^7.25.7",
-                "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.25.7",
-                "@babel/plugin-transform-dynamic-import": "^7.25.7",
-                "@babel/plugin-transform-exponentiation-operator": "^7.25.7",
-                "@babel/plugin-transform-export-namespace-from": "^7.25.7",
-                "@babel/plugin-transform-for-of": "^7.25.7",
-                "@babel/plugin-transform-function-name": "^7.25.7",
-                "@babel/plugin-transform-json-strings": "^7.25.7",
-                "@babel/plugin-transform-literals": "^7.25.7",
-                "@babel/plugin-transform-logical-assignment-operators": "^7.25.7",
-                "@babel/plugin-transform-member-expression-literals": "^7.25.7",
-                "@babel/plugin-transform-modules-amd": "^7.25.7",
-                "@babel/plugin-transform-modules-commonjs": "^7.25.7",
-                "@babel/plugin-transform-modules-systemjs": "^7.25.7",
-                "@babel/plugin-transform-modules-umd": "^7.25.7",
-                "@babel/plugin-transform-named-capturing-groups-regex": "^7.25.7",
-                "@babel/plugin-transform-new-target": "^7.25.7",
-                "@babel/plugin-transform-nullish-coalescing-operator": "^7.25.7",
-                "@babel/plugin-transform-numeric-separator": "^7.25.7",
-                "@babel/plugin-transform-object-rest-spread": "^7.25.7",
-                "@babel/plugin-transform-object-super": "^7.25.7",
-                "@babel/plugin-transform-optional-catch-binding": "^7.25.7",
-                "@babel/plugin-transform-optional-chaining": "^7.25.7",
-                "@babel/plugin-transform-parameters": "^7.25.7",
-                "@babel/plugin-transform-private-methods": "^7.25.7",
-                "@babel/plugin-transform-private-property-in-object": "^7.25.7",
-                "@babel/plugin-transform-property-literals": "^7.25.7",
-                "@babel/plugin-transform-regenerator": "^7.25.7",
-                "@babel/plugin-transform-reserved-words": "^7.25.7",
-                "@babel/plugin-transform-shorthand-properties": "^7.25.7",
-                "@babel/plugin-transform-spread": "^7.25.7",
-                "@babel/plugin-transform-sticky-regex": "^7.25.7",
-                "@babel/plugin-transform-template-literals": "^7.25.7",
-                "@babel/plugin-transform-typeof-symbol": "^7.25.7",
-                "@babel/plugin-transform-unicode-escapes": "^7.25.7",
-                "@babel/plugin-transform-unicode-property-regex": "^7.25.7",
-                "@babel/plugin-transform-unicode-regex": "^7.25.7",
-                "@babel/plugin-transform-unicode-sets-regex": "^7.25.7",
+                "@babel/plugin-transform-arrow-functions": "^7.25.9",
+                "@babel/plugin-transform-async-generator-functions": "^7.25.9",
+                "@babel/plugin-transform-async-to-generator": "^7.25.9",
+                "@babel/plugin-transform-block-scoped-functions": "^7.25.9",
+                "@babel/plugin-transform-block-scoping": "^7.25.9",
+                "@babel/plugin-transform-class-properties": "^7.25.9",
+                "@babel/plugin-transform-class-static-block": "^7.26.0",
+                "@babel/plugin-transform-classes": "^7.25.9",
+                "@babel/plugin-transform-computed-properties": "^7.25.9",
+                "@babel/plugin-transform-destructuring": "^7.25.9",
+                "@babel/plugin-transform-dotall-regex": "^7.25.9",
+                "@babel/plugin-transform-duplicate-keys": "^7.25.9",
+                "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.25.9",
+                "@babel/plugin-transform-dynamic-import": "^7.25.9",
+                "@babel/plugin-transform-exponentiation-operator": "^7.25.9",
+                "@babel/plugin-transform-export-namespace-from": "^7.25.9",
+                "@babel/plugin-transform-for-of": "^7.25.9",
+                "@babel/plugin-transform-function-name": "^7.25.9",
+                "@babel/plugin-transform-json-strings": "^7.25.9",
+                "@babel/plugin-transform-literals": "^7.25.9",
+                "@babel/plugin-transform-logical-assignment-operators": "^7.25.9",
+                "@babel/plugin-transform-member-expression-literals": "^7.25.9",
+                "@babel/plugin-transform-modules-amd": "^7.25.9",
+                "@babel/plugin-transform-modules-commonjs": "^7.25.9",
+                "@babel/plugin-transform-modules-systemjs": "^7.25.9",
+                "@babel/plugin-transform-modules-umd": "^7.25.9",
+                "@babel/plugin-transform-named-capturing-groups-regex": "^7.25.9",
+                "@babel/plugin-transform-new-target": "^7.25.9",
+                "@babel/plugin-transform-nullish-coalescing-operator": "^7.25.9",
+                "@babel/plugin-transform-numeric-separator": "^7.25.9",
+                "@babel/plugin-transform-object-rest-spread": "^7.25.9",
+                "@babel/plugin-transform-object-super": "^7.25.9",
+                "@babel/plugin-transform-optional-catch-binding": "^7.25.9",
+                "@babel/plugin-transform-optional-chaining": "^7.25.9",
+                "@babel/plugin-transform-parameters": "^7.25.9",
+                "@babel/plugin-transform-private-methods": "^7.25.9",
+                "@babel/plugin-transform-private-property-in-object": "^7.25.9",
+                "@babel/plugin-transform-property-literals": "^7.25.9",
+                "@babel/plugin-transform-regenerator": "^7.25.9",
+                "@babel/plugin-transform-regexp-modifiers": "^7.26.0",
+                "@babel/plugin-transform-reserved-words": "^7.25.9",
+                "@babel/plugin-transform-shorthand-properties": "^7.25.9",
+                "@babel/plugin-transform-spread": "^7.25.9",
+                "@babel/plugin-transform-sticky-regex": "^7.25.9",
+                "@babel/plugin-transform-template-literals": "^7.25.9",
+                "@babel/plugin-transform-typeof-symbol": "^7.25.9",
+                "@babel/plugin-transform-unicode-escapes": "^7.25.9",
+                "@babel/plugin-transform-unicode-property-regex": "^7.25.9",
+                "@babel/plugin-transform-unicode-regex": "^7.25.9",
+                "@babel/plugin-transform-unicode-sets-regex": "^7.25.9",
                 "@babel/preset-modules": "0.1.6-no-external-plugins",
                 "babel-plugin-polyfill-corejs2": "^0.4.10",
                 "babel-plugin-polyfill-corejs3": "^0.10.6",
@@ -2292,7 +1759,6 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
-            "license": "ISC",
             "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -2303,7 +1769,6 @@
             "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
             "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.0.0",
@@ -2315,11 +1780,10 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-            "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+            "version": "7.26.0",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
+            "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
@@ -2329,34 +1793,32 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.7.tgz",
-            "integrity": "sha512-wRwtAgI3bAS+JGU2upWNL9lSlDcRCqD05BZ1n3X2ONLH1WilFP6O1otQjeMK/1g0pvYcXC7b/qVUB1keofjtZA==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
+            "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/code-frame": "^7.25.7",
-                "@babel/parser": "^7.25.7",
-                "@babel/types": "^7.25.7"
+                "@babel/code-frame": "^7.25.9",
+                "@babel/parser": "^7.25.9",
+                "@babel/types": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.7.tgz",
-            "integrity": "sha512-jatJPT1Zjqvh/1FyJs6qAHL+Dzb7sTb+xr7Q+gM1b+1oBsMsQQ4FkVKb6dFlJvLlVssqkRzV05Jzervt9yhnzg==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.9.tgz",
+            "integrity": "sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/code-frame": "^7.25.7",
-                "@babel/generator": "^7.25.7",
-                "@babel/parser": "^7.25.7",
-                "@babel/template": "^7.25.7",
-                "@babel/types": "^7.25.7",
+                "@babel/code-frame": "^7.25.9",
+                "@babel/generator": "^7.25.9",
+                "@babel/parser": "^7.25.9",
+                "@babel/template": "^7.25.9",
+                "@babel/types": "^7.25.9",
                 "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
@@ -2369,21 +1831,18 @@
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=4"
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.7.tgz",
-            "integrity": "sha512-vwIVdXG+j+FOpkwqHRcBgHLYNL7XMkufrlaFvL9o6Ai9sJn9+PdyIL5qa0XzTZw084c+u9LOls53eoZWP/W5WQ==",
-            "license": "MIT",
+            "version": "7.26.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
+            "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.25.7",
-                "@babel/helper-validator-identifier": "^7.25.7",
-                "to-fast-properties": "^2.0.0"
+                "@babel/helper-string-parser": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2393,7 +1852,6 @@
             "version": "11.0.3",
             "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz",
             "integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
-            "license": "Apache-2.0",
             "dependencies": {
                 "@chevrotain/gast": "11.0.3",
                 "@chevrotain/types": "11.0.3",
@@ -2404,7 +1862,6 @@
             "version": "11.0.3",
             "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
             "integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
-            "license": "Apache-2.0",
             "dependencies": {
                 "@chevrotain/types": "11.0.3",
                 "lodash-es": "4.17.21"
@@ -2413,26 +1870,22 @@
         "node_modules/@chevrotain/regexp-to-ast": {
             "version": "11.0.3",
             "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.0.3.tgz",
-            "integrity": "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA==",
-            "license": "Apache-2.0"
+            "integrity": "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA=="
         },
         "node_modules/@chevrotain/types": {
             "version": "11.0.3",
             "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz",
-            "integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==",
-            "license": "Apache-2.0"
+            "integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ=="
         },
         "node_modules/@chevrotain/utils": {
             "version": "11.0.3",
             "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
-            "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
-            "license": "Apache-2.0"
+            "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ=="
         },
         "node_modules/@codingame/monaco-vscode-base-service-override": {
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-8.0.4.tgz",
             "integrity": "sha512-tTIA68KRYgSPHyanjqTUGQro+t67vShxAGNjM2Iz7dhqMOYZhYA4oIwI4Q0A+QWBC2HKOCNkwFoc5pqconw5YA==",
-            "license": "MIT",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
             }
@@ -2441,7 +1894,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-configuration-service-override/-/monaco-vscode-configuration-service-override-8.0.4.tgz",
             "integrity": "sha512-Fx8wRY3G2s3fpcQWGBMEe7fUmDhPFSkn+b/DwPCTiyo9IX+uKk8w097XjJBwCk0wVHgOcYs4GKPsip5IqJkydw==",
-            "license": "MIT",
             "dependencies": {
                 "@codingame/monaco-vscode-files-service-override": "8.0.4",
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
@@ -2451,7 +1903,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-editor-service-override/-/monaco-vscode-editor-service-override-8.0.4.tgz",
             "integrity": "sha512-is77poIqjYAcve9AYlUrkMfgtjWlH1D9ebxGjk4Y2UHvmQvsrRFuaGvzEt4YpgNLd+0hSyuH+R0HWSOq3uN2BA==",
-            "license": "MIT",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
             }
@@ -2460,7 +1911,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-8.0.4.tgz",
             "integrity": "sha512-3PBqEag0RaACIYiPdtDqxn4BS48yMq1uNCrNYm9E2P1On7JaCLNPHrQfE9Et6HbJT9qPzdcfbD5IwevQbCym5Q==",
-            "license": "MIT",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
             }
@@ -2469,7 +1919,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-8.0.4.tgz",
             "integrity": "sha512-uEOpSXGxC6W3uaKwj5p+WXsvkVqD1ONDNOCy8ZEHskpkN6KO/0XE927OvpF75JsqXHjNTmstSxTjU9/GykpruA==",
-            "license": "MIT",
             "dependencies": {
                 "@codingame/monaco-vscode-files-service-override": "8.0.4",
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
@@ -2479,7 +1928,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-8.0.4.tgz",
             "integrity": "sha512-DCvbxgE6wwOoUsKGlinOB7vYx7HoVUviqWY913Fux4K7/wYWpBcNVtK8kmKs7euPJPeAsl06PJFaXaS3Qjfkqg==",
-            "license": "MIT",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
             }
@@ -2488,7 +1936,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-8.0.4.tgz",
             "integrity": "sha512-VT8jFmnzMpi6DuSgA8c/F0MVh+fApLH75ledgMqfsKC1vSDOkV0IaPPBHRfPYDPvXCrnOtfdpvP0hFrdg1ytig==",
-            "license": "MIT",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
             }
@@ -2497,7 +1944,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-cs/-/monaco-vscode-language-pack-cs-8.0.4.tgz",
             "integrity": "sha512-ijeMCVxDhNv2M1h92pMCYx8P4nBUTWlAisnAnrDASNJa3V6bFjCo+r0jXKruOjZhjtO0VOYsX0r1s0VUq1Otuw==",
-            "license": "MIT",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
             }
@@ -2506,7 +1952,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-de/-/monaco-vscode-language-pack-de-8.0.4.tgz",
             "integrity": "sha512-OehZUq8+z8KDnZPBH0xEU+Ph+D9GTssFPcMzdvxLSfY0xyxNDfC+rCemLGAfJydtONVKde5WsOWvozM5PJ+uEQ==",
-            "license": "MIT",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
             }
@@ -2515,7 +1960,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-es/-/monaco-vscode-language-pack-es-8.0.4.tgz",
             "integrity": "sha512-+mB2aeWnn+Nz4s8zopaEQWqhZLvsUM/SGcsqpjy/liU0D6M8qhc8XyAbOS3dORTFtFVIhxj/MVW7I8E2fhJd1Q==",
-            "license": "MIT",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
             }
@@ -2524,7 +1968,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-fr/-/monaco-vscode-language-pack-fr-8.0.4.tgz",
             "integrity": "sha512-nhWM+uOVSzcnIGYr9GCEX00GJjgUt9xoW+TKLG1axayCpPboDoD8mbafaycNoYkz3aJIwhYytpKIzhl05EmIhg==",
-            "license": "MIT",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
             }
@@ -2533,7 +1976,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-it/-/monaco-vscode-language-pack-it-8.0.4.tgz",
             "integrity": "sha512-BXXLAakXU8zumxQH9uRX4KIIPy/ZJjdI/7DWriASs0BU2rJwta9cRmGZshpl9IJMVB4HHLmUvEoXv3NXfGIu8A==",
-            "license": "MIT",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
             }
@@ -2542,7 +1984,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-ja/-/monaco-vscode-language-pack-ja-8.0.4.tgz",
             "integrity": "sha512-G4Dv75fCZuRNL6lo0/T71iGVvRaIP039PV4icOZv2sIxatQEIPcnI89Bc4obHRmX8IzKIPKG4OYNixDzRno8dA==",
-            "license": "MIT",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
             }
@@ -2551,7 +1992,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-ko/-/monaco-vscode-language-pack-ko-8.0.4.tgz",
             "integrity": "sha512-+RSYTNci7V8EdaAzHKn5OGo9GH3LE9v1B4/MHo2d1iNvvsB3jJ3p4I69E7w0+g3cr7B+gFGfJYAvDHdQABd5Gg==",
-            "license": "MIT",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
             }
@@ -2560,7 +2000,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-pl/-/monaco-vscode-language-pack-pl-8.0.4.tgz",
             "integrity": "sha512-YlFJEqUQ2j1bSiVBz1o59RZDsFaPVfhbnosMWV4B1iqW0qEXtQwUfdMeU0N8H3fq2v2ov6W79dOu9PlWyOW4Ww==",
-            "license": "MIT",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
             }
@@ -2569,7 +2008,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-pt-br/-/monaco-vscode-language-pack-pt-br-8.0.4.tgz",
             "integrity": "sha512-kwoVrjIYZhmRwajt3qrYRr6KW0UVxC/YV/c+MOjr2HKMUgy5fqo+BKmj/9lSfduyu5JPddZxKARTBw0oByVghA==",
-            "license": "MIT",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
             }
@@ -2578,7 +2016,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-qps-ploc/-/monaco-vscode-language-pack-qps-ploc-8.0.4.tgz",
             "integrity": "sha512-TJK9YuCHf2RHK3NcoiIAgjyna1lv6ndN70t13wf9pN+GyOE7XfYUVJj0YrQDbNCXiSeaTxgJtt0VQZmeN6RHjQ==",
-            "license": "MIT",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
             }
@@ -2587,7 +2024,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-ru/-/monaco-vscode-language-pack-ru-8.0.4.tgz",
             "integrity": "sha512-4rZDZU9VNJCIDM8hwLJQYhUnsQu3qcVONpb1muRFGKYhh9NwAELAwl2XW+ybsTC/B/4Qysk7cB1IxrTt4AhNjg==",
-            "license": "MIT",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
             }
@@ -2596,7 +2032,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-tr/-/monaco-vscode-language-pack-tr-8.0.4.tgz",
             "integrity": "sha512-cqtF5drmuFp/wKmJvm9l6Unc+AF4vn48t0KJBZ1/QRxTZnRlwT5Dm+z0JR880O8WsSUkzJIG93/wBAzpv+6/Bg==",
-            "license": "MIT",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
             }
@@ -2605,7 +2040,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-zh-hans/-/monaco-vscode-language-pack-zh-hans-8.0.4.tgz",
             "integrity": "sha512-a8R+IUggCI/UVv4uDy7XzjOwB3WAt+KX8ElsAqzJB9Y5BbFW5/a1Pxca0UXJ2vQabcls4TcrIi2yR30jnlBgww==",
-            "license": "MIT",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
             }
@@ -2614,7 +2048,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-zh-hant/-/monaco-vscode-language-pack-zh-hant-8.0.4.tgz",
             "integrity": "sha512-g3b/apaTc/bg5isOEvxir38bbYzd/CuBY0MWtXw1NKXc0GPsTo4j5eAuT2R4qT1pJ9XgbMBbYQAMLX3DxSJRxA==",
-            "license": "MIT",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
             }
@@ -2623,7 +2056,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-languages-service-override/-/monaco-vscode-languages-service-override-8.0.4.tgz",
             "integrity": "sha512-GXd2fKQa96tNv0gFB3nT/yWUc+4pZM/2L8KcfOOuNRWEOjm9TbOWmNZyWGi2Abf4vAdLNKVtJBX1+SoDkwoQdw==",
-            "license": "MIT",
             "dependencies": {
                 "@codingame/monaco-vscode-files-service-override": "8.0.4",
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
@@ -2633,7 +2065,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-8.0.4.tgz",
             "integrity": "sha512-DrF1vRJG8vPOaqC06fu99yjvtIcuTza5vAQdH19FfDi87vyk3BeFsnj7H7Z0fRK/wQigBcNzXYbUkuE93I95IQ==",
-            "license": "MIT",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
             }
@@ -2642,7 +2073,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-localization-service-override/-/monaco-vscode-localization-service-override-8.0.4.tgz",
             "integrity": "sha512-z/MGZXSW69y3pIxbXobRfoGadN82BSSO7tu3jkhJx3c3CpvULaDl5HLUKoXDwtG14/nEA/VCzI/MOHp/bXBKDQ==",
-            "license": "MIT",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
             }
@@ -2651,7 +2081,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-model-service-override/-/monaco-vscode-model-service-override-8.0.4.tgz",
             "integrity": "sha512-oynV9SnSE1MfqtVjqDWy/xcmekmAVNzyoqTh6oH3B+Oy/nhPqI6X9yIA0I47u0ncs/wjj3dDVnXOEv2IqJXxZg==",
-            "license": "MIT",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
             }
@@ -2660,7 +2089,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-monarch-service-override/-/monaco-vscode-monarch-service-override-8.0.4.tgz",
             "integrity": "sha512-OrlE+ffvGf9C6xfkcO6rEiuy4GJQJQ+dSByxHyfLXA9qCWn/dHpYfjpr83YIlBG0tNoBdAYnx2iLgAo6y5Tzkw==",
-            "license": "MIT",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
             }
@@ -2669,7 +2097,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-8.0.4.tgz",
             "integrity": "sha512-VXHVKRqtieKf+BTTUwcT++tJEb/k7PI2vLR3Lgsh2t0We7ydPOPLTDA99/Ls3yuM+i6IvKqBXc+WomN8MRS1rw==",
-            "license": "MIT",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
             }
@@ -2678,7 +2105,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-textmate-service-override/-/monaco-vscode-textmate-service-override-8.0.4.tgz",
             "integrity": "sha512-YDJoXCqnEimotWcqUlzU8bBah3+dqLAcIULJEV07K2DMFkKty78sc6w2CAItIlzmTeJApW2HpTdOgZehYqro3w==",
-            "license": "MIT",
             "dependencies": {
                 "@codingame/monaco-vscode-files-service-override": "8.0.4",
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4",
@@ -2690,7 +2116,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-theme-defaults-default-extension/-/monaco-vscode-theme-defaults-default-extension-8.0.4.tgz",
             "integrity": "sha512-y2M0i2ZUGdQbbZ5/rfGQzDe0McUWOVDu0HrIBKhGCyVMfeR7nII06jipQD0e/XPY1cmphyi/x1U70AX2msJEQQ==",
-            "license": "MIT",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
             }
@@ -2699,41 +2124,37 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-theme-service-override/-/monaco-vscode-theme-service-override-8.0.4.tgz",
             "integrity": "sha512-z2UpL7KQJ/gg1LUP9ya65Qph30bypwiQT+mq9ZM699nQEPpXJ9HGA5AiHE2rf2wlKnbkmis1gdpIXeYQsDLy0g==",
-            "license": "MIT",
             "dependencies": {
                 "@codingame/monaco-vscode-files-service-override": "8.0.4",
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
             }
         },
         "node_modules/@docsearch/css": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.6.2.tgz",
-            "integrity": "sha512-vKNZepO2j7MrYBTZIGXvlUOIR+v9KRf70FApRgovWrj3GTs1EITz/Xb0AOlm1xsQBp16clVZj1SY/qaOJbQtZw==",
-            "dev": true,
-            "license": "MIT"
+            "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.0.tgz",
+            "integrity": "sha512-pieeipSOW4sQ0+bE5UFC51AOZp9NGxg89wAlZ1BAQFaiRAGK1IKUaPQ0UGZeNctJXyqZ1UvBtOQh2HH+U5GtmA==",
+            "dev": true
         },
         "node_modules/@docsearch/js": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.6.2.tgz",
-            "integrity": "sha512-pS4YZF+VzUogYrkblCucQ0Oy2m8Wggk8Kk7lECmZM60hTbaydSIhJTTiCrmoxtBqV8wxORnOqcqqOfbmkkQEcA==",
+            "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.0.tgz",
+            "integrity": "sha512-PVuV629f5UcYRtBWqK7ID6vNL5647+2ADJypwTjfeBIrJfwPuHtzLy39hMGMfFK+0xgRyhTR0FZ83EkdEraBlg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@docsearch/react": "3.6.2",
+                "@docsearch/react": "3.8.0",
                 "preact": "^10.0.0"
             }
         },
         "node_modules/@docsearch/react": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.6.2.tgz",
-            "integrity": "sha512-rtZce46OOkVflCQH71IdbXSFK+S8iJZlUF56XBW5rIgx/eG5qoomC7Ag3anZson1bBac/JFQn7XOBfved/IMRA==",
+            "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.0.tgz",
+            "integrity": "sha512-WnFK720+iwTVt94CxY3u+FgX6exb3BfN5kE9xUY6uuAH/9W/UFboBZFLlrw/zxFRHoHZCOXRtOylsXF+6LHI+Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@algolia/autocomplete-core": "1.9.3",
-                "@algolia/autocomplete-preset-algolia": "1.9.3",
-                "@docsearch/css": "3.6.2",
-                "algoliasearch": "^4.19.1"
+                "@algolia/autocomplete-core": "1.17.7",
+                "@algolia/autocomplete-preset-algolia": "1.17.7",
+                "@docsearch/css": "3.8.0",
+                "algoliasearch": "^5.12.0"
             },
             "peerDependencies": {
                 "@types/react": ">= 16.8.0 < 19.0.0",
@@ -2764,7 +2185,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "aix"
@@ -2781,7 +2201,6 @@
                 "arm"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
@@ -2798,7 +2217,6 @@
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
@@ -2815,7 +2233,6 @@
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
@@ -2832,7 +2249,6 @@
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -2849,7 +2265,6 @@
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -2866,7 +2281,6 @@
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "freebsd"
@@ -2883,7 +2297,6 @@
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "freebsd"
@@ -2900,7 +2313,6 @@
                 "arm"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -2917,7 +2329,6 @@
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -2934,7 +2345,6 @@
                 "ia32"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -2951,7 +2361,6 @@
                 "loong64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -2968,7 +2377,6 @@
                 "mips64el"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -2985,7 +2393,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -3002,7 +2409,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -3019,7 +2425,6 @@
                 "s390x"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -3036,7 +2441,6 @@
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -3053,7 +2457,6 @@
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "netbsd"
@@ -3070,7 +2473,6 @@
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "openbsd"
@@ -3087,7 +2489,6 @@
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "sunos"
@@ -3104,7 +2505,6 @@
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -3121,7 +2521,6 @@
                 "ia32"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -3138,7 +2537,6 @@
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -3148,16 +2546,18 @@
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-            "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
+            "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "eslint-visitor-keys": "^3.3.0"
+                "eslint-visitor-keys": "^3.4.3"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             },
             "peerDependencies": {
                 "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
@@ -3168,7 +2568,6 @@
             "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
             "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
             }
@@ -3223,7 +2622,6 @@
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
             "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
@@ -3247,7 +2645,6 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3258,7 +2655,6 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -3289,7 +2685,6 @@
             "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
             "integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
             "dev": true,
-            "license": "Apache-2.0",
             "dependencies": {
                 "levn": "^0.4.1"
             },
@@ -3302,7 +2697,6 @@
             "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
             "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
             "dev": true,
-            "license": "Apache-2.0",
             "engines": {
                 "node": ">=18.18.0"
             }
@@ -3312,7 +2706,6 @@
             "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
             "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
             "dev": true,
-            "license": "Apache-2.0",
             "dependencies": {
                 "@humanfs/core": "^0.19.1",
                 "@humanwhocodes/retry": "^0.3.0"
@@ -3326,7 +2719,6 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
             "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
             "dev": true,
-            "license": "Apache-2.0",
             "engines": {
                 "node": ">=18.18"
             },
@@ -3340,7 +2732,6 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
             "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
             "dev": true,
-            "license": "Apache-2.0",
             "engines": {
                 "node": ">=12.22"
             },
@@ -3354,7 +2745,6 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
             "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
             "dev": true,
-            "license": "Apache-2.0",
             "engines": {
                 "node": ">=18.18"
             },
@@ -3408,11 +2798,10 @@
             "link": true
         },
         "node_modules/@iconify-json/simple-icons": {
-            "version": "1.2.11",
-            "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.11.tgz",
-            "integrity": "sha512-AHCGDtBRqP+JzAbBzgO8uN/08CXxEmuaC6lQQZ3b5burKhRU12AJnJczwbUw2K5Mb/U85EpSUNhYMG3F28b8NA==",
+            "version": "1.2.12",
+            "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.12.tgz",
+            "integrity": "sha512-lRNORrIdeLStShxAjN6FgXE1iMkaAgiAHZdP0P0GZecX91FVYW58uZnRSlXLlSx5cxMoELulkAAixybPA2g52g==",
             "dev": true,
-            "license": "CC0-1.0",
             "dependencies": {
                 "@iconify/types": "*"
             }
@@ -3421,15 +2810,13 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
             "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
             "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@jridgewell/set-array": "^1.2.1",
@@ -3445,7 +2832,6 @@
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
             "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=6.0.0"
@@ -3456,7 +2842,6 @@
             "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
             "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=6.0.0"
@@ -3467,7 +2852,6 @@
             "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
             "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
@@ -3477,15 +2861,13 @@
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-            "license": "MIT"
+            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.25",
             "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
             "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
@@ -3531,7 +2913,6 @@
             "version": "1.15.10",
             "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-1.15.10.tgz",
             "integrity": "sha512-0JT29/LaxVgRcGKvHmSrUTEvZ8BXvZhGl2LASRUgHqDTC1M5g1pLmVv56IYNyt3bG2CUjDkc67wnyZC14pbQrQ==",
-            "license": "MIT",
             "dependencies": {
                 "@oozcitak/infra": "1.0.8",
                 "@oozcitak/url": "1.0.4",
@@ -3545,7 +2926,6 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@oozcitak/infra/-/infra-1.0.8.tgz",
             "integrity": "sha512-JRAUc9VR6IGHOL7OGF+yrvs0LO8SlqGnPAMqyzOuFZPSZSXI7Xf2O9+awQPSMXgIWGtgUf/dA6Hs6X6ySEaWTg==",
-            "license": "MIT",
             "dependencies": {
                 "@oozcitak/util": "8.3.8"
             },
@@ -3557,7 +2937,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/@oozcitak/url/-/url-1.0.4.tgz",
             "integrity": "sha512-kDcD8y+y3FCSOvnBI6HJgl00viO/nGbQoCINmQ0h98OhnGITrWR3bOGfwYCthgcrV8AnTJz8MzslTQbC3SOAmw==",
-            "license": "MIT",
             "dependencies": {
                 "@oozcitak/infra": "1.0.8",
                 "@oozcitak/util": "8.3.8"
@@ -3570,7 +2949,6 @@
             "version": "8.3.8",
             "resolved": "https://registry.npmjs.org/@oozcitak/util/-/util-8.3.8.tgz",
             "integrity": "sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==",
-            "license": "MIT",
             "engines": {
                 "node": ">=8.0"
             }
@@ -3580,7 +2958,6 @@
             "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
             "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
             },
@@ -3593,7 +2970,6 @@
             "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.0.tgz",
             "integrity": "sha512-9eO5McEICxMzJpDW9OnMYSv4Sta3hmt7VtBFz5zR9273suNOydOyq/FrGeGy+KsTRFm8w0SLVhzig2ILFT63Ag==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@rollup/pluginutils": "^5.0.1",
                 "@types/resolve": "1.20.2",
@@ -3618,7 +2994,6 @@
             "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
             "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "serialize-javascript": "^6.0.1",
@@ -3642,7 +3017,6 @@
             "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-12.1.1.tgz",
             "integrity": "sha512-t7O653DpfB5MbFrqPe/VcKFFkvRuFNp9qId3xq4Eth5xlyymzxNpye2z8Hrl0RIMuXTSr5GGcFpkdlMeacUiFQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@rollup/pluginutils": "^5.1.0",
                 "resolve": "^1.22.1"
@@ -3669,7 +3043,6 @@
             "resolved": "https://registry.npmjs.org/@rollup/plugin-wasm/-/plugin-wasm-6.2.2.tgz",
             "integrity": "sha512-gpC4R1G9Ni92ZIRTexqbhX7U+9estZrbhP+9SRb0DW9xpB9g7j34r+J2hqrcW/lRI7dJaU84MxZM0Rt82tqYPQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@rollup/pluginutils": "^5.0.2"
             },
@@ -3686,15 +3059,14 @@
             }
         },
         "node_modules/@rollup/pluginutils": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.2.tgz",
-            "integrity": "sha512-/FIdS3PyZ39bjZlwqFnWqCOVnW7o963LtKMwQOD0NhQqw22gSr2YY1afu3FxRip4ZCZNsD5jq6Aaz6QV3D/Njw==",
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.3.tgz",
+            "integrity": "sha512-Pnsb6f32CD2W3uCaLZIzDmeFyQ2b8UWMFI7xtwUezpcGBDVDW6y9XgAWIlARiGAo6eNF5FK5aQTr0LFyNyqq5A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/estree": "^1.0.0",
                 "estree-walker": "^2.0.2",
-                "picomatch": "^2.3.1"
+                "picomatch": "^4.0.2"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -3708,225 +3080,247 @@
                 }
             }
         },
+        "node_modules/@rollup/pluginutils/node_modules/picomatch": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.24.0.tgz",
-            "integrity": "sha512-Q6HJd7Y6xdB48x8ZNVDOqsbh2uByBhgK8PiQgPhwkIw/HC/YX5Ghq2mQY5sRMZWHb3VsFkWooUVOZHKr7DmDIA==",
+            "version": "4.27.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.27.3.tgz",
+            "integrity": "sha512-EzxVSkIvCFxUd4Mgm4xR9YXrcp976qVaHnqom/Tgm+vU79k4vV4eYTjmRvGfeoW8m9LVcsAy/lGjcgVegKEhLQ==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.24.0.tgz",
-            "integrity": "sha512-ijLnS1qFId8xhKjT81uBHuuJp2lU4x2yxa4ctFPtG+MqEE6+C5f/+X/bStmxapgmwLwiL3ih122xv8kVARNAZA==",
+            "version": "4.27.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.27.3.tgz",
+            "integrity": "sha512-LJc5pDf1wjlt9o/Giaw9Ofl+k/vLUaYsE2zeQGH85giX2F+wn/Cg8b3c5CDP3qmVmeO5NzwVUzQQxwZvC2eQKw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.24.0.tgz",
-            "integrity": "sha512-bIv+X9xeSs1XCk6DVvkO+S/z8/2AMt/2lMqdQbMrmVpgFvXlmde9mLcbQpztXm1tajC3raFDqegsH18HQPMYtA==",
+            "version": "4.27.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.27.3.tgz",
+            "integrity": "sha512-OuRysZ1Mt7wpWJ+aYKblVbJWtVn3Cy52h8nLuNSzTqSesYw1EuN6wKp5NW/4eSre3mp12gqFRXOKTcN3AI3LqA==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.24.0.tgz",
-            "integrity": "sha512-X6/nOwoFN7RT2svEQWUsW/5C/fYMBe4fnLK9DQk4SX4mgVBiTA9h64kjUYPvGQ0F/9xwJ5U5UfTbl6BEjaQdBQ==",
+            "version": "4.27.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.27.3.tgz",
+            "integrity": "sha512-xW//zjJMlJs2sOrCmXdB4d0uiilZsOdlGQIC/jjmMWT47lkLLoB1nsNhPUcnoqyi5YR6I4h+FjBpILxbEy8JRg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
             ]
         },
+        "node_modules/@rollup/rollup-freebsd-arm64": {
+            "version": "4.27.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.27.3.tgz",
+            "integrity": "sha512-58E0tIcwZ+12nK1WiLzHOD8I0d0kdrY/+o7yFVPRHuVGY3twBwzwDdTIBGRxLmyjciMYl1B/U515GJy+yn46qw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-x64": {
+            "version": "4.27.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.27.3.tgz",
+            "integrity": "sha512-78fohrpcVwTLxg1ZzBMlwEimoAJmY6B+5TsyAZ3Vok7YabRBUvjYTsRXPTjGEvv/mfgVBepbW28OlMEz4w8wGA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.24.0.tgz",
-            "integrity": "sha512-0KXvIJQMOImLCVCz9uvvdPgfyWo93aHHp8ui3FrtOP57svqrF/roSSR5pjqL2hcMp0ljeGlU4q9o/rQaAQ3AYA==",
+            "version": "4.27.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.27.3.tgz",
+            "integrity": "sha512-h2Ay79YFXyQi+QZKo3ISZDyKaVD7uUvukEHTOft7kh00WF9mxAaxZsNs3o/eukbeKuH35jBvQqrT61fzKfAB/Q==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.24.0.tgz",
-            "integrity": "sha512-it2BW6kKFVh8xk/BnHfakEeoLPv8STIISekpoF+nBgWM4d55CZKc7T4Dx1pEbTnYm/xEKMgy1MNtYuoA8RFIWw==",
+            "version": "4.27.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.27.3.tgz",
+            "integrity": "sha512-Sv2GWmrJfRY57urktVLQ0VKZjNZGogVtASAgosDZ1aUB+ykPxSi3X1nWORL5Jk0sTIIwQiPH7iE3BMi9zGWfkg==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.24.0.tgz",
-            "integrity": "sha512-i0xTLXjqap2eRfulFVlSnM5dEbTVque/3Pi4g2y7cxrs7+a9De42z4XxKLYJ7+OhE3IgxvfQM7vQc43bwTgPwA==",
+            "version": "4.27.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.27.3.tgz",
+            "integrity": "sha512-FPoJBLsPW2bDNWjSrwNuTPUt30VnfM8GPGRoLCYKZpPx0xiIEdFip3dH6CqgoT0RnoGXptaNziM0WlKgBc+OWQ==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.24.0.tgz",
-            "integrity": "sha512-9E6MKUJhDuDh604Qco5yP/3qn3y7SLXYuiC0Rpr89aMScS2UAmK1wHP2b7KAa1nSjWJc/f/Lc0Wl1L47qjiyQw==",
+            "version": "4.27.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.27.3.tgz",
+            "integrity": "sha512-TKxiOvBorYq4sUpA0JT+Fkh+l+G9DScnG5Dqx7wiiqVMiRSkzTclP35pE6eQQYjP4Gc8yEkJGea6rz4qyWhp3g==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.24.0.tgz",
-            "integrity": "sha512-2XFFPJ2XMEiF5Zi2EBf4h73oR1V/lycirxZxHZNc93SqDN/IWhYYSYj8I9381ikUFXZrz2v7r2tOVk2NBwxrWw==",
+            "version": "4.27.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.27.3.tgz",
+            "integrity": "sha512-v2M/mPvVUKVOKITa0oCFksnQQ/TqGrT+yD0184/cWHIu0LoIuYHwox0Pm3ccXEz8cEQDLk6FPKd1CCm+PlsISw==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.24.0.tgz",
-            "integrity": "sha512-M3Dg4hlwuntUCdzU7KjYqbbd+BLq3JMAOhCKdBE3TcMGMZbKkDdJ5ivNdehOssMCIokNHFOsv7DO4rlEOfyKpg==",
+            "version": "4.27.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.27.3.tgz",
+            "integrity": "sha512-LdrI4Yocb1a/tFVkzmOE5WyYRgEBOyEhWYJe4gsDWDiwnjYKjNs7PS6SGlTDB7maOHF4kxevsuNBl2iOcj3b4A==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.24.0.tgz",
-            "integrity": "sha512-mjBaoo4ocxJppTorZVKWFpy1bfFj9FeCMJqzlMQGjpNPY9JwQi7OuS1axzNIk0nMX6jSgy6ZURDZ2w0QW6D56g==",
+            "version": "4.27.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.27.3.tgz",
+            "integrity": "sha512-d4wVu6SXij/jyiwPvI6C4KxdGzuZOvJ6y9VfrcleHTwo68fl8vZC5ZYHsCVPUi4tndCfMlFniWgwonQ5CUpQcA==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.24.0.tgz",
-            "integrity": "sha512-ZXFk7M72R0YYFN5q13niV0B7G8/5dcQ9JDp8keJSfr3GoZeXEoMHP/HlvqROA3OMbMdfr19IjCeNAnPUG93b6A==",
+            "version": "4.27.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.27.3.tgz",
+            "integrity": "sha512-/6bn6pp1fsCGEY5n3yajmzZQAh+mW4QPItbiWxs69zskBzJuheb3tNynEjL+mKOsUSFK11X4LYF2BwwXnzWleA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.24.0.tgz",
-            "integrity": "sha512-w1i+L7kAXZNdYl+vFvzSZy8Y1arS7vMgIy8wusXJzRrPyof5LAb02KGr1PD2EkRcl73kHulIID0M501lN+vobQ==",
+            "version": "4.27.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.27.3.tgz",
+            "integrity": "sha512-nBXOfJds8OzUT1qUreT/en3eyOXd2EH5b0wr2bVB5999qHdGKkzGzIyKYaKj02lXk6wpN71ltLIaQpu58YFBoQ==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.24.0.tgz",
-            "integrity": "sha512-VXBrnPWgBpVDCVY6XF3LEW0pOU51KbaHhccHw6AS6vBWIC60eqsH19DAeeObl+g8nKAz04QFdl/Cefta0xQtUQ==",
+            "version": "4.27.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.27.3.tgz",
+            "integrity": "sha512-ogfbEVQgIZOz5WPWXF2HVb6En+kWzScuxJo/WdQTqEgeyGkaa2ui5sQav9Zkr7bnNCLK48uxmmK0TySm22eiuw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.24.0.tgz",
-            "integrity": "sha512-xrNcGDU0OxVcPTH/8n/ShH4UevZxKIO6HJFK0e15XItZP2UcaiLFd5kiX7hJnqCbSztUF8Qot+JWBC/QXRPYWQ==",
+            "version": "4.27.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.27.3.tgz",
+            "integrity": "sha512-ecE36ZBMLINqiTtSNQ1vzWc5pXLQHlf/oqGp/bSbi7iedcjcNb6QbCBNG73Euyy2C+l/fn8qKWEwxr+0SSfs3w==",
             "cpu": [
                 "ia32"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.24.0.tgz",
-            "integrity": "sha512-fbMkAF7fufku0N2dE5TBXcNlg0pt0cJue4xBRE2Qc5Vqikxr4VCgKj/ht6SMdFcOacVA9rqF70APJ8RN/4vMJw==",
+            "version": "4.27.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.27.3.tgz",
+            "integrity": "sha512-vliZLrDmYKyaUoMzEbMTg2JkerfBjn03KmAw9CykO0Zzkzoyd7o3iZNam/TpyWNjNT+Cz2iO3P9Smv2wgrR+Eg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -3937,7 +3331,6 @@
             "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.23.1.tgz",
             "integrity": "sha512-NuOVgwcHgVC6jBVH5V7iblziw6iQbWWHrj5IlZI3Fqu2yx9awH7OIQkXIcsHsUmY19ckwSgUMgrqExEyP5A0TA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@shikijs/engine-javascript": "1.23.1",
                 "@shikijs/engine-oniguruma": "1.23.1",
@@ -3952,7 +3345,6 @@
             "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.23.1.tgz",
             "integrity": "sha512-i/LdEwT5k3FVu07SiApRFwRcSJs5QM9+tod5vYCPig1Ywi8GR30zcujbxGQFJHwYD7A5BUqagi8o5KS+LEVgBg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@shikijs/types": "1.23.1",
                 "@shikijs/vscode-textmate": "^9.3.0",
@@ -3964,7 +3356,6 @@
             "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.23.1.tgz",
             "integrity": "sha512-KQ+lgeJJ5m2ISbUZudLR1qHeH3MnSs2mjFg7bnencgs5jDVPeJ2NVDJ3N5ZHbcTsOIh0qIueyAJnwg7lg7kwXQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@shikijs/types": "1.23.1",
                 "@shikijs/vscode-textmate": "^9.3.0"
@@ -3975,7 +3366,6 @@
             "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.23.1.tgz",
             "integrity": "sha512-yQ2Cn0M9i46p30KwbyIzLvKDk+dQNU+lj88RGO0XEj54Hn4Cof1bZoDb9xBRWxFE4R8nmK63w7oHnJwvOtt0NQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "shiki": "1.23.1"
             }
@@ -3985,7 +3375,6 @@
             "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.23.1.tgz",
             "integrity": "sha512-98A5hGyEhzzAgQh2dAeHKrWW4HfCMeoFER2z16p5eJ+vmPeF6lZ/elEne6/UCU551F/WqkopqRsr1l2Yu6+A0g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@shikijs/vscode-textmate": "^9.3.0",
                 "@types/hast": "^3.0.4"
@@ -3995,15 +3384,13 @@
             "version": "9.3.0",
             "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.3.0.tgz",
             "integrity": "sha512-jn7/7ky30idSkd/O5yDBfAnVt+JJpepofP/POZ1iMOxK59cOfqIgg/Dj0eFsjOTMw+4ycJN0uhZH/Eb0bs/EUA==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/@surma/rollup-plugin-off-main-thread": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
             "integrity": "sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==",
             "dev": true,
-            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
                 "ejs": "^3.1.6",
@@ -4017,48 +3404,42 @@
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
             "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "sourcemap-codec": "^1.4.8"
             }
         },
         "node_modules/@swc/helpers": {
-            "version": "0.5.13",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.13.tgz",
-            "integrity": "sha512-UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==",
-            "license": "Apache-2.0",
+            "version": "0.5.15",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+            "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
             "dependencies": {
-                "tslib": "^2.4.0"
+                "tslib": "^2.8.0"
             }
         },
         "node_modules/@types/bezier-js": {
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/@types/bezier-js/-/bezier-js-4.1.3.tgz",
             "integrity": "sha512-FNVVCu5mx/rJCWBxLTcL7oOajmGtWtBTDjq6DSUWUI12GeePivrZZXz+UgE0D6VYsLEjvExRO03z4hVtu3pTEQ==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/@types/estree": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
             "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/@types/file-saver": {
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.7.tgz",
             "integrity": "sha512-dNKVfHd/jk0SkR/exKGj2ggkB45MAkzvWCaqLUUgkyjITkGNzH8H+yUwr+BLJUBjZOe9w8X3wgmXhZDRg1ED6A==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/@types/fontkit": {
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/@types/fontkit/-/fontkit-2.0.7.tgz",
             "integrity": "sha512-f5BjGam6y3FrfEY2JxXwba66SYzqP+FREZh4UuBN1WDePl8EhTKjba3ZZQ2iORUufkrFt/c/UIugj0Uv/HEdRg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
             }
@@ -4068,7 +3449,6 @@
             "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
             "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/unist": "*"
             }
@@ -4077,22 +3457,19 @@
             "version": "7.0.15",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/@types/linkify-it": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
             "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/@types/markdown-it": {
             "version": "14.1.2",
             "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
             "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/linkify-it": "^5",
                 "@types/mdurl": "^2"
@@ -4103,7 +3480,6 @@
             "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
             "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/unist": "*"
             }
@@ -4112,32 +3488,28 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
             "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/@types/node": {
-            "version": "22.7.4",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.4.tgz",
-            "integrity": "sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==",
+            "version": "22.9.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.1.tgz",
+            "integrity": "sha512-p8Yy/8sw1caA8CdRIQBG5tiLHmxtQKObCijiAa9Ez+d4+PRffM4054xbju0msf+cvhJpnFEeNjxmVT/0ipktrg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "undici-types": "~6.19.2"
+                "undici-types": "~6.19.8"
             }
         },
         "node_modules/@types/pako": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.3.tgz",
             "integrity": "sha512-bq0hMV9opAcrmE0Byyo0fY3Ew4tgOevJmQ9grUhpXQhYfyLJ1Kqg3P33JT5fdbT2AjeAjR51zqqVjAL/HMkx7Q==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/@types/pdfkit": {
             "version": "0.13.5",
             "resolved": "https://registry.npmjs.org/@types/pdfkit/-/pdfkit-0.13.5.tgz",
             "integrity": "sha512-cR4gZA3xiMVDUf/O/ijVr6aIguvN72ZmCDLcWwM0ycqn5P8XDSjMX9PixzWEoDnlINoofxo2LCdV4KvdD9Waqg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
             }
@@ -4146,43 +3518,37 @@
             "version": "1.20.2",
             "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
             "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/@types/trusted-types": {
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
             "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/@types/unist": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
             "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/@types/uuid": {
             "version": "10.0.0",
             "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
             "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/@types/web-bluetooth": {
             "version": "0.0.20",
             "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
-            "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==",
-            "license": "MIT"
+            "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow=="
         },
         "node_modules/@types/wicg-file-system-access": {
             "version": "2023.10.5",
             "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2023.10.5.tgz",
             "integrity": "sha512-e9kZO9kCdLqT2h9Tw38oGv9UNzBBWaR1MzuAavxPcsV/7FJ3tWbU6RI3uB+yKIDPGLkGVbplS52ub0AcRLvrhA==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "8.15.0",
@@ -4390,15 +3756,13 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
             "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
-            "dev": true,
-            "license": "ISC"
+            "dev": true
         },
         "node_modules/@vite-pwa/vitepress": {
             "version": "0.5.3",
             "resolved": "https://registry.npmjs.org/@vite-pwa/vitepress/-/vitepress-0.5.3.tgz",
             "integrity": "sha512-ZNtBxZhS5Enp66z01gKuovTQzSorIpc6o9FEVwOk7kNivzuc4Q5RB04fcbBI1qqHE67rDmm+XqVQw0nj801gmw==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
             },
@@ -4413,11 +3777,10 @@
             }
         },
         "node_modules/@vitejs/plugin-vue": {
-            "version": "5.1.4",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.1.4.tgz",
-            "integrity": "sha512-N2XSI2n3sQqp5w7Y/AN/L2XDjBIRGqXko+eDp42sydYSBeJuSm5a1sLf8zakmo8u7tA8NmBgoDLA1HeOESjp9A==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.0.tgz",
+            "integrity": "sha512-7n7KdUEtx/7Yl7I/WVAMZ1bEb0eVvXF3ummWTeLcs/9gvo9pJhuLdouSXGjdZ/MKD1acf1I272+X0RMua4/R3g==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "^18.0.0 || >=20.0.0"
             },
@@ -4429,14 +3792,12 @@
         "node_modules/@vscode/iconv-lite-umd": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/@vscode/iconv-lite-umd/-/iconv-lite-umd-0.7.0.tgz",
-            "integrity": "sha512-bRRFxLfg5dtAyl5XyiVWz/ZBPahpOpPrNYnnHpOpUZvam4tKH35wdhP4Kj6PbM0+KdliOsPzbGWpkxcdpNB/sg==",
-            "license": "MIT"
+            "integrity": "sha512-bRRFxLfg5dtAyl5XyiVWz/ZBPahpOpPrNYnnHpOpUZvam4tKH35wdhP4Kj6PbM0+KdliOsPzbGWpkxcdpNB/sg=="
         },
         "node_modules/@vue/compiler-core": {
             "version": "3.5.13",
             "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
             "integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
-            "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.25.3",
                 "@vue/shared": "3.5.13",
@@ -4449,7 +3810,6 @@
             "version": "3.5.13",
             "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz",
             "integrity": "sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==",
-            "license": "MIT",
             "dependencies": {
                 "@vue/compiler-core": "3.5.13",
                 "@vue/shared": "3.5.13"
@@ -4459,7 +3819,6 @@
             "version": "3.5.13",
             "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.13.tgz",
             "integrity": "sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==",
-            "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.25.3",
                 "@vue/compiler-core": "3.5.13",
@@ -4476,7 +3835,6 @@
             "version": "3.5.13",
             "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.13.tgz",
             "integrity": "sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==",
-            "license": "MIT",
             "dependencies": {
                 "@vue/compiler-dom": "3.5.13",
                 "@vue/shared": "3.5.13"
@@ -4487,7 +3845,6 @@
             "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.6.4.tgz",
             "integrity": "sha512-5AaJ5ELBIuevmFMZYYLuOO9HUuY/6OlkOELHE7oeDhy4XD/hSODIzktlsvBOsn+bto3aD0psj36LGzwVu5Ip8w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@vue/devtools-kit": "^7.6.4"
             }
@@ -4497,7 +3854,6 @@
             "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.6.4.tgz",
             "integrity": "sha512-Zs86qIXXM9icU0PiGY09PQCle4TI750IPLmAJzW5Kf9n9t5HzSYf6Rz6fyzSwmfMPiR51SUKJh9sXVZu78h2QA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@vue/devtools-shared": "^7.6.4",
                 "birpc": "^0.2.19",
@@ -4513,7 +3869,6 @@
             "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.6.4.tgz",
             "integrity": "sha512-nD6CUvBEel+y7zpyorjiUocy0nh77DThZJ0k1GRnJeOmY3ATq2fWijEp7wk37gb023Cb0R396uYh5qMSBQ5WFg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "rfdc": "^1.4.1"
             }
@@ -4522,7 +3877,6 @@
             "version": "3.5.13",
             "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.13.tgz",
             "integrity": "sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==",
-            "license": "MIT",
             "dependencies": {
                 "@vue/shared": "3.5.13"
             }
@@ -4531,7 +3885,6 @@
             "version": "3.5.13",
             "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.13.tgz",
             "integrity": "sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==",
-            "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "3.5.13",
                 "@vue/shared": "3.5.13"
@@ -4541,7 +3894,6 @@
             "version": "3.5.13",
             "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.13.tgz",
             "integrity": "sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==",
-            "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "3.5.13",
                 "@vue/runtime-core": "3.5.13",
@@ -4553,7 +3905,6 @@
             "version": "3.5.13",
             "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.13.tgz",
             "integrity": "sha512-wAi4IRJV/2SAW3htkTlB+dHeRmpTiVIK1OGLWV1yeStVSebSQQOwGwIq0D3ZIoBj2C2qpgz5+vX9iEBkTdk5YA==",
-            "license": "MIT",
             "dependencies": {
                 "@vue/compiler-ssr": "3.5.13",
                 "@vue/shared": "3.5.13"
@@ -4565,19 +3916,16 @@
         "node_modules/@vue/shared": {
             "version": "3.5.13",
             "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
-            "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
-            "license": "MIT"
+            "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ=="
         },
         "node_modules/@vueuse/core": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-11.1.0.tgz",
-            "integrity": "sha512-P6dk79QYA6sKQnghrUz/1tHi0n9mrb/iO1WTMk/ElLmTyNqgDeSZ3wcDf6fRBGzRJbeG1dxzEOvLENMjr+E3fg==",
-            "dev": true,
-            "license": "MIT",
+            "version": "11.3.0",
+            "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-11.3.0.tgz",
+            "integrity": "sha512-7OC4Rl1f9G8IT6rUfi9JrKiXy4bfmHhZ5x2Ceojy0jnd3mHNEvV4JaRygH362ror6/NZ+Nl+n13LPzGiPN8cKA==",
             "dependencies": {
                 "@types/web-bluetooth": "^0.0.20",
-                "@vueuse/metadata": "11.1.0",
-                "@vueuse/shared": "11.1.0",
+                "@vueuse/metadata": "11.3.0",
+                "@vueuse/shared": "11.3.0",
                 "vue-demi": ">=0.14.10"
             },
             "funding": {
@@ -4588,9 +3936,7 @@
             "version": "0.14.10",
             "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
             "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-            "dev": true,
             "hasInstallScript": true,
-            "license": "MIT",
             "bin": {
                 "vue-demi-fix": "bin/vue-demi-fix.js",
                 "vue-demi-switch": "bin/vue-demi-switch.js"
@@ -4612,14 +3958,13 @@
             }
         },
         "node_modules/@vueuse/integrations": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-11.1.0.tgz",
-            "integrity": "sha512-O2ZgrAGPy0qAjpoI2YR3egNgyEqwG85fxfwmA9BshRIGjV4G6yu6CfOPpMHAOoCD+UfsIl7Vb1bXJ6ifrHYDDA==",
+            "version": "11.3.0",
+            "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-11.3.0.tgz",
+            "integrity": "sha512-5fzRl0apQWrDezmobchoiGTkGw238VWESxZHazfhP3RM7pDSiyXy18QbfYkILoYNTd23HPAfQTJpkUc5QbkwTw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@vueuse/core": "11.1.0",
-                "@vueuse/shared": "11.1.0",
+                "@vueuse/core": "11.3.0",
+                "@vueuse/shared": "11.3.0",
                 "vue-demi": ">=0.14.10"
             },
             "funding": {
@@ -4684,7 +4029,6 @@
             "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
             "dev": true,
             "hasInstallScript": true,
-            "license": "MIT",
             "bin": {
                 "vue-demi-fix": "bin/vue-demi-fix.js",
                 "vue-demi-switch": "bin/vue-demi-switch.js"
@@ -4706,21 +4050,17 @@
             }
         },
         "node_modules/@vueuse/metadata": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-11.1.0.tgz",
-            "integrity": "sha512-l9Q502TBTaPYGanl1G+hPgd3QX5s4CGnpXriVBR5fEZ/goI6fvDaVmIl3Td8oKFurOxTmbXvBPSsgrd6eu6HYg==",
-            "dev": true,
-            "license": "MIT",
+            "version": "11.3.0",
+            "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-11.3.0.tgz",
+            "integrity": "sha512-pwDnDspTqtTo2HwfLw4Rp6yywuuBdYnPYDq+mO38ZYKGebCUQC/nVj/PXSiK9HX5otxLz8Fn7ECPbjiRz2CC3g==",
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/@vueuse/shared": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-11.1.0.tgz",
-            "integrity": "sha512-YUtIpY122q7osj+zsNMFAfMTubGz0sn5QzE5gPzAIiCmtt2ha3uQUY1+JPyL4gRCTsLPX82Y9brNbo/aqlA91w==",
-            "dev": true,
-            "license": "MIT",
+            "version": "11.3.0",
+            "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-11.3.0.tgz",
+            "integrity": "sha512-P8gSSWQeucH5821ek2mn/ciCk+MS/zoRKqdQIM3bHq6p7GXDAJLmnRRKmF5F65sAVJIfzQlwR3aDzwCn10s8hA==",
             "dependencies": {
                 "vue-demi": ">=0.14.10"
             },
@@ -4732,9 +4072,7 @@
             "version": "0.14.10",
             "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
             "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-            "dev": true,
             "hasInstallScript": true,
-            "license": "MIT",
             "bin": {
                 "vue-demi-fix": "bin/vue-demi-fix.js",
                 "vue-demi-switch": "bin/vue-demi-switch.js"
@@ -4760,7 +4098,6 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
             "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
             "dev": true,
-            "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -4773,7 +4110,6 @@
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "dev": true,
-            "license": "MIT",
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
@@ -4783,7 +4119,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -4796,70 +4131,27 @@
             }
         },
         "node_modules/algoliasearch": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.24.0.tgz",
-            "integrity": "sha512-bf0QV/9jVejssFBmz2HQLxUadxk574t4iwjCKp5E7NBzwKkrDEhKPISIIjAU/p6K5qDx3qoeh4+26zWN1jmw3g==",
+            "version": "5.15.0",
+            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.15.0.tgz",
+            "integrity": "sha512-Yf3Swz1s63hjvBVZ/9f2P1Uu48GjmjCN+Esxb6MAONMGtZB1fRX8/S1AhUTtsuTlcGovbYLxpHgc7wEzstDZBw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@algolia/cache-browser-local-storage": "4.24.0",
-                "@algolia/cache-common": "4.24.0",
-                "@algolia/cache-in-memory": "4.24.0",
-                "@algolia/client-account": "4.24.0",
-                "@algolia/client-analytics": "4.24.0",
-                "@algolia/client-common": "4.24.0",
-                "@algolia/client-personalization": "4.24.0",
-                "@algolia/client-search": "4.24.0",
-                "@algolia/logger-common": "4.24.0",
-                "@algolia/logger-console": "4.24.0",
-                "@algolia/recommend": "4.24.0",
-                "@algolia/requester-browser-xhr": "4.24.0",
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/requester-node-http": "4.24.0",
-                "@algolia/transporter": "4.24.0"
-            }
-        },
-        "node_modules/algoliasearch/node_modules/@algolia/client-common": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
-            "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/transporter": "4.24.0"
-            }
-        },
-        "node_modules/algoliasearch/node_modules/@algolia/client-search": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
-            "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/client-common": "4.24.0",
-                "@algolia/requester-common": "4.24.0",
-                "@algolia/transporter": "4.24.0"
-            }
-        },
-        "node_modules/algoliasearch/node_modules/@algolia/requester-browser-xhr": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.24.0.tgz",
-            "integrity": "sha512-Z2NxZMb6+nVXSjF13YpjYTdvV3032YTBSGm2vnYvYPA6mMxzM3v5rsCiSspndn9rzIW4Qp1lPHBvuoKJV6jnAA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/requester-common": "4.24.0"
-            }
-        },
-        "node_modules/algoliasearch/node_modules/@algolia/requester-node-http": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.24.0.tgz",
-            "integrity": "sha512-JF18yTjNOVYvU/L3UosRcvbPMGT9B+/GQWNWnenIImglzNVGpyzChkXLnrSf6uxwVNO6ESGu6oN8MqcGQcjQJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/requester-common": "4.24.0"
+                "@algolia/client-abtesting": "5.15.0",
+                "@algolia/client-analytics": "5.15.0",
+                "@algolia/client-common": "5.15.0",
+                "@algolia/client-insights": "5.15.0",
+                "@algolia/client-personalization": "5.15.0",
+                "@algolia/client-query-suggestions": "5.15.0",
+                "@algolia/client-search": "5.15.0",
+                "@algolia/ingestion": "1.15.0",
+                "@algolia/monitoring": "1.15.0",
+                "@algolia/recommend": "5.15.0",
+                "@algolia/requester-browser-xhr": "5.15.0",
+                "@algolia/requester-fetch": "5.15.0",
+                "@algolia/requester-node-http": "5.15.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/ansi-styles": {
@@ -4867,7 +4159,6 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -4882,14 +4173,12 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true,
-            "license": "Python-2.0"
+            "dev": true
         },
         "node_modules/array-buffer-byte-length": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
             "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
-            "license": "MIT",
             "dependencies": {
                 "call-bind": "^1.0.5",
                 "is-array-buffer": "^3.0.4"
@@ -4906,7 +4195,6 @@
             "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
             "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "array-buffer-byte-length": "^1.0.1",
@@ -4930,16 +4218,6 @@
             "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
             "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/asynckit": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
             "peer": true
         },
         "node_modules/at-least-node": {
@@ -4947,7 +4225,6 @@
             "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
             "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
             "dev": true,
-            "license": "ISC",
             "peer": true,
             "engines": {
                 "node": ">= 4.0.0"
@@ -4956,14 +4233,12 @@
         "node_modules/autocompleter": {
             "version": "9.3.2",
             "resolved": "https://registry.npmjs.org/autocompleter/-/autocompleter-9.3.2.tgz",
-            "integrity": "sha512-rLbf2TLGOD7y+gOS36ksrZdIsvoHa2KXc2A7503w+NBRPrcF73zzFeYBxEcV/iMPjaBH3jFhNIYObZ7zt1fkCQ==",
-            "license": "MIT"
+            "integrity": "sha512-rLbf2TLGOD7y+gOS36ksrZdIsvoHa2KXc2A7503w+NBRPrcF73zzFeYBxEcV/iMPjaBH3jFhNIYObZ7zt1fkCQ=="
         },
         "node_modules/available-typed-arrays": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
             "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-            "license": "MIT",
             "dependencies": {
                 "possible-typed-array-names": "^1.0.0"
             },
@@ -4974,30 +4249,15 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/axios": {
-            "version": "1.7.7",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-            "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
-            }
-        },
         "node_modules/babel-plugin-polyfill-corejs2": {
-            "version": "0.4.11",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.11.tgz",
-            "integrity": "sha512-sMEJ27L0gRHShOh5G54uAAPaiCOygY/5ratXuiyb2G46FmlSpc9eFCzYVyDiPxfNbwzA7mYahmjQc5q+CZQ09Q==",
+            "version": "0.4.12",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.12.tgz",
+            "integrity": "sha512-CPWT6BwvhrTO2d8QVorhTCQw9Y43zOu7G9HigcfxvepOU6b8o3tcWad6oVgZIsZCTt42FFv97aA7ZJsbM4+8og==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@babel/compat-data": "^7.22.6",
-                "@babel/helper-define-polyfill-provider": "^0.6.2",
+                "@babel/helper-define-polyfill-provider": "^0.6.3",
                 "semver": "^6.3.1"
             },
             "peerDependencies": {
@@ -5009,7 +4269,6 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
-            "license": "ISC",
             "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -5020,7 +4279,6 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.6.tgz",
             "integrity": "sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@babel/helper-define-polyfill-provider": "^0.6.2",
@@ -5031,14 +4289,13 @@
             }
         },
         "node_modules/babel-plugin-polyfill-regenerator": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.2.tgz",
-            "integrity": "sha512-2R25rQZWP63nGwaAswvDazbPXfrM3HwVoBXK6HcqeKrSrL/JqcC/rDcf95l4r7LXLyxDXc8uQDa064GubtCABg==",
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.3.tgz",
+            "integrity": "sha512-LiWSbl4CRSIa5x/JAU6jZiG9eit9w6mz+yVMFwDE83LAWvt0AfGBoZ7HS/mkhrKuh2ZlzfVZYKoLjXdqw6Yt7Q==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/helper-define-polyfill-provider": "^0.6.2"
+                "@babel/helper-define-polyfill-provider": "^0.6.3"
             },
             "peerDependencies": {
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -5047,8 +4304,7 @@
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "license": "MIT"
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
         },
         "node_modules/base64-js": {
             "version": "1.5.1",
@@ -5067,14 +4323,12 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ],
-            "license": "MIT"
+            ]
         },
         "node_modules/bezier-js": {
             "version": "6.1.4",
             "resolved": "https://registry.npmjs.org/bezier-js/-/bezier-js-6.1.4.tgz",
             "integrity": "sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==",
-            "license": "MIT",
             "funding": {
                 "type": "individual",
                 "url": "https://github.com/Pomax/bezierjs/blob/master/FUNDING.md"
@@ -5085,7 +4339,6 @@
             "resolved": "https://registry.npmjs.org/birpc/-/birpc-0.2.19.tgz",
             "integrity": "sha512-5WeXXAvTmitV1RqJFppT5QtUiz2p1mRSYU000Jkft5ZUCLJIk4uQriYNO50HknxKwM6jd8utNc66K1qGIwwWBQ==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
             }
@@ -5094,7 +4347,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
             "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
@@ -5115,15 +4367,14 @@
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
             "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
-            "license": "MIT",
             "dependencies": {
                 "base64-js": "^1.1.2"
             }
         },
         "node_modules/browserslist": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
-            "integrity": "sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==",
+            "version": "4.24.2",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
+            "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
             "dev": true,
             "funding": [
                 {
@@ -5139,13 +4390,12 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "caniuse-lite": "^1.0.30001663",
-                "electron-to-chromium": "^1.5.28",
+                "caniuse-lite": "^1.0.30001669",
+                "electron-to-chromium": "^1.5.41",
                 "node-releases": "^2.0.18",
-                "update-browserslist-db": "^1.1.0"
+                "update-browserslist-db": "^1.1.1"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -5172,7 +4422,6 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.2.1"
@@ -5183,14 +4432,12 @@
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/call-bind": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
             "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
-            "license": "MIT",
             "dependencies": {
                 "es-define-property": "^1.0.0",
                 "es-errors": "^1.3.0",
@@ -5210,15 +4457,14 @@
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001667",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001667.tgz",
-            "integrity": "sha512-7LTwJjcRkzKFmtqGsibMeuXmvFDfZq/nzIjnmgCGzKKRVzjD72selLDK1oPF/Oxzmt4fNcPvTDvGqSDG4tCALw==",
+            "version": "1.0.30001683",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001683.tgz",
+            "integrity": "sha512-iqmNnThZ0n70mNwvxpEC2nBJ037ZHZUoBI5Gorh1Mw6IlEAZujEoU1tXA628iZfzm7R9FvFzxbfdgml82a3k8Q==",
             "dev": true,
             "funding": [
                 {
@@ -5234,7 +4480,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "CC-BY-4.0",
             "peer": true
         },
         "node_modules/ccount": {
@@ -5242,7 +4487,6 @@
             "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
             "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -5253,7 +4497,6 @@
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -5270,7 +4513,6 @@
             "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
             "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -5281,7 +4523,6 @@
             "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
             "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -5291,7 +4532,6 @@
             "version": "11.0.3",
             "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
             "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
-            "license": "Apache-2.0",
             "dependencies": {
                 "@chevrotain/cst-dts-gen": "11.0.3",
                 "@chevrotain/gast": "11.0.3",
@@ -5305,7 +4545,6 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
             "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-            "license": "MIT",
             "engines": {
                 "node": ">=0.8"
             }
@@ -5315,7 +4554,6 @@
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -5327,50 +4565,30 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/combined-stream": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "delayed-stream": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
+            "dev": true
         },
         "node_modules/comma-separated-tokens": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
             "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/commander": {
-            "version": "12.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-            "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            }
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "dev": true,
+            "peer": true
         },
         "node_modules/common-tags": {
             "version": "1.8.2",
             "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
             "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=4.0.0"
@@ -5380,15 +4598,13 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/convert-source-map": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
             "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/copy-anything": {
@@ -5396,7 +4612,6 @@
             "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
             "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "is-what": "^4.1.8"
             },
@@ -5408,14 +4623,13 @@
             }
         },
         "node_modules/core-js-compat": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.38.1.tgz",
-            "integrity": "sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==",
+            "version": "3.39.0",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.39.0.tgz",
+            "integrity": "sha512-VgEUx3VwlExr5no0tXlBt+silBvhTryPwCXRI2Id1PN8WTKu7MreethvddqOubrYxkFdv/RnYrqlv1sFNAUelw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "browserslist": "^4.23.3"
+                "browserslist": "^4.24.2"
             },
             "funding": {
                 "type": "opencollective",
@@ -5423,11 +4637,10 @@
             }
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
-            "integrity": "sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -5440,15 +4653,13 @@
         "node_modules/crypto-js": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-            "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
-            "license": "MIT"
+            "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
         },
         "node_modules/crypto-random-string": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
             "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=8"
@@ -5457,15 +4668,13 @@
         "node_modules/csstype": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-            "license": "MIT"
+            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         },
         "node_modules/data-view-buffer": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
             "integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.6",
@@ -5484,7 +4693,6 @@
             "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
             "integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.7",
@@ -5503,7 +4711,6 @@
             "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
             "integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.6",
@@ -5522,7 +4729,6 @@
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
             "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -5539,7 +4745,6 @@
             "version": "1.5.3",
             "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
             "integrity": "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==",
-            "license": "MIT",
             "peerDependencies": {
                 "babel-plugin-macros": "^3.1.0"
             },
@@ -5553,7 +4758,6 @@
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
             "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-            "license": "MIT",
             "dependencies": {
                 "array-buffer-byte-length": "^1.0.0",
                 "call-bind": "^1.0.5",
@@ -5585,15 +4789,13 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/deepmerge": {
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
             "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -5602,7 +4804,6 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
             "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-            "license": "MIT",
             "dependencies": {
                 "es-define-property": "^1.0.0",
                 "es-errors": "^1.3.0",
@@ -5619,7 +4820,6 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
             "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-            "license": "MIT",
             "dependencies": {
                 "define-data-property": "^1.0.1",
                 "has-property-descriptors": "^1.0.0",
@@ -5632,24 +4832,11 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/delayed-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
         "node_modules/dequal": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
             "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
@@ -5659,7 +4846,6 @@
             "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
             "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "dequal": "^2.0.0"
             },
@@ -5671,15 +4857,13 @@
         "node_modules/dfa": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
-            "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
-            "license": "MIT"
+            "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q=="
         },
         "node_modules/ejs": {
             "version": "3.1.10",
             "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
             "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
             "dev": true,
-            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
                 "jake": "^10.8.5"
@@ -5692,25 +4876,22 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.33",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.33.tgz",
-            "integrity": "sha512-+cYTcFB1QqD4j4LegwLfpCNxifb6dDFUAwk6RsLusCwIaZI6or2f+q8rs5tTB2YC53HhOlIbEaqHMAAC8IOIwA==",
+            "version": "1.5.64",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.64.tgz",
+            "integrity": "sha512-IXEuxU+5ClW2IGEYFC2T7szbyVgehupCWQe5GNh+H065CD6U6IFN0s4KeAMFGNmQolRU4IV7zGBWSYMmZ8uuqQ==",
             "dev": true,
-            "license": "ISC",
             "peer": true
         },
         "node_modules/emoji-regex-xs": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
             "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/entities": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
             "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-            "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.12"
             },
@@ -5719,11 +4900,10 @@
             }
         },
         "node_modules/es-abstract": {
-            "version": "1.23.3",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
-            "integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
+            "version": "1.23.5",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.5.tgz",
+            "integrity": "sha512-vlmniQ0WNPwXqA0BnmwV3Ng7HxiGlh6r5U6JcTMNx8OilcAGqVJBHJcPjqOMaczU9fRuRK5Px2BdVyPRnKMMVQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "array-buffer-byte-length": "^1.0.1",
@@ -5741,7 +4921,7 @@
                 "function.prototype.name": "^1.1.6",
                 "get-intrinsic": "^1.2.4",
                 "get-symbol-description": "^1.0.2",
-                "globalthis": "^1.0.3",
+                "globalthis": "^1.0.4",
                 "gopd": "^1.0.1",
                 "has-property-descriptors": "^1.0.2",
                 "has-proto": "^1.0.3",
@@ -5757,10 +4937,10 @@
                 "is-string": "^1.0.7",
                 "is-typed-array": "^1.1.13",
                 "is-weakref": "^1.0.2",
-                "object-inspect": "^1.13.1",
+                "object-inspect": "^1.13.3",
                 "object-keys": "^1.1.1",
                 "object.assign": "^4.1.5",
-                "regexp.prototype.flags": "^1.5.2",
+                "regexp.prototype.flags": "^1.5.3",
                 "safe-array-concat": "^1.1.2",
                 "safe-regex-test": "^1.0.3",
                 "string.prototype.trim": "^1.2.9",
@@ -5784,7 +4964,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
             "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-            "license": "MIT",
             "dependencies": {
                 "get-intrinsic": "^1.2.4"
             },
@@ -5796,7 +4975,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             }
@@ -5805,7 +4983,6 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
             "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-            "license": "MIT",
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "get-intrinsic": "^1.1.3",
@@ -5826,7 +5003,6 @@
             "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
             "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "es-errors": "^1.3.0"
@@ -5840,7 +5016,6 @@
             "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
             "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "get-intrinsic": "^1.2.4",
@@ -5856,7 +5031,6 @@
             "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
             "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "is-callable": "^1.1.4",
@@ -5876,7 +5050,6 @@
             "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
             "dev": true,
             "hasInstallScript": true,
-            "license": "MIT",
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -5914,7 +5087,6 @@
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
             "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=6"
@@ -5925,7 +5097,6 @@
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -5997,7 +5168,6 @@
             "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
             "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
             "dev": true,
-            "license": "MIT",
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
             },
@@ -6010,7 +5180,6 @@
             "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.1.tgz",
             "integrity": "sha512-gH3iR3g4JfF+yYPaJYkN7jEl9QbweL/YfkoRlNnuIEHEz1vHVlCmWOS+eGGiRuzHQXdJFCOTxRgvju9b8VUmrw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "prettier-linter-helpers": "^1.0.0",
                 "synckit": "^0.9.1"
@@ -6041,7 +5210,6 @@
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
             "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^5.2.0"
@@ -6058,7 +5226,6 @@
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
             "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
             "dev": true,
-            "license": "Apache-2.0",
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             },
@@ -6071,7 +5238,6 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -6082,7 +5248,6 @@
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
             "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
             "dev": true,
-            "license": "Apache-2.0",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
@@ -6095,7 +5260,6 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -6108,7 +5272,6 @@
             "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
             "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "dependencies": {
                 "acorn": "^8.14.0",
                 "acorn-jsx": "^5.3.2",
@@ -6126,7 +5289,6 @@
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
             "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
             "dev": true,
-            "license": "Apache-2.0",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
@@ -6138,7 +5300,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "license": "BSD-2-Clause",
             "bin": {
                 "esparse": "bin/esparse.js",
                 "esvalidate": "bin/esvalidate.js"
@@ -6152,7 +5313,6 @@
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
             "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "dependencies": {
                 "estraverse": "^5.1.0"
             },
@@ -6165,7 +5325,6 @@
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
             "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "dependencies": {
                 "estraverse": "^5.2.0"
             },
@@ -6178,7 +5337,6 @@
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=4.0"
             }
@@ -6186,15 +5344,13 @@
         "node_modules/estree-walker": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "license": "MIT"
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
         },
         "node_modules/esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -6202,15 +5358,13 @@
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "license": "MIT"
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "node_modules/fast-diff": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
             "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
-            "dev": true,
-            "license": "Apache-2.0"
+            "dev": true
         },
         "node_modules/fast-glob": {
             "version": "3.3.2",
@@ -6244,22 +5398,19 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/fast-uri": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.2.tgz",
-            "integrity": "sha512-GR6f0hD7XXyNJa25Tb9BuIdN0tdr+0BMi6/CJPH3wJO1JjNG3n/VsSw38AwRdKZABm8lGbPfakLRkYzx2V9row==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
+            "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/fastq": {
@@ -6276,7 +5427,6 @@
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
             "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "flat-cache": "^4.0.0"
             },
@@ -6287,15 +5437,13 @@
         "node_modules/file-saver": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
-            "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==",
-            "license": "MIT"
+            "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
         },
         "node_modules/filelist": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
             "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
             "dev": true,
-            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
                 "minimatch": "^5.0.1"
@@ -6306,7 +5454,6 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
             "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
             "dev": true,
-            "license": "ISC",
             "peer": true,
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -6332,7 +5479,6 @@
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
             "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "locate-path": "^6.0.0",
                 "path-exists": "^4.0.0"
@@ -6349,7 +5495,6 @@
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
             "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "flatted": "^3.2.9",
                 "keyv": "^4.5.4"
@@ -6359,50 +5504,24 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-            "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
-            "dev": true,
-            "license": "ISC"
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
+            "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
+            "dev": true
         },
         "node_modules/focus-trap": {
-            "version": "7.6.0",
-            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.0.tgz",
-            "integrity": "sha512-1td0l3pMkWJLFipobUcGaf+5DTY4PLDDrcqoSaKP8ediO/CoWCCYk/fT/Y2A4e6TNB+Sh6clRJCjOPPnKoNHnQ==",
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.2.tgz",
+            "integrity": "sha512-9FhUxK1hVju2+AiQIDJ5Dd//9R2n2RAfJ0qfhF4IHGHgcoEUTMpbTeG/zbEuwaiYXfuAH6XE0/aCyxDdRM+W5w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "tabbable": "^6.2.0"
-            }
-        },
-        "node_modules/follow-redirects": {
-            "version": "1.15.9",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-            "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
             }
         },
         "node_modules/fontkit": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
             "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
-            "license": "MIT",
             "dependencies": {
                 "@swc/helpers": "^0.5.12",
                 "brotli": "^1.3.2",
@@ -6419,26 +5538,8 @@
             "version": "0.3.3",
             "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
             "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-            "license": "MIT",
             "dependencies": {
                 "is-callable": "^1.1.3"
-            }
-        },
-        "node_modules/form-data": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/fs-extra": {
@@ -6446,7 +5547,6 @@
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
             "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "at-least-node": "^1.0.0",
@@ -6463,7 +5563,6 @@
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "dev": true,
-            "license": "ISC",
             "peer": true
         },
         "node_modules/fsevents": {
@@ -6472,7 +5571,6 @@
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
             "dev": true,
             "hasInstallScript": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -6485,7 +5583,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
             "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -6495,7 +5592,6 @@
             "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
             "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
@@ -6514,7 +5610,6 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
             "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -6524,7 +5619,6 @@
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
             "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -6534,7 +5628,6 @@
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
             "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "function-bind": "^1.1.2",
@@ -6554,7 +5647,6 @@
             "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
             "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
             "dev": true,
-            "license": "ISC",
             "peer": true
         },
         "node_modules/get-symbol-description": {
@@ -6562,7 +5654,6 @@
             "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
             "integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.5",
@@ -6582,7 +5673,6 @@
             "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
             "deprecated": "Glob versions prior to v9 are no longer supported",
             "dev": true,
-            "license": "ISC",
             "peer": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -6604,7 +5694,6 @@
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
             "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "is-glob": "^4.0.3"
             },
@@ -6617,7 +5706,6 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -6629,7 +5717,6 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
-            "license": "ISC",
             "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -6643,7 +5730,6 @@
             "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
             "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -6656,7 +5742,6 @@
             "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
             "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "define-properties": "^1.2.1",
@@ -6673,7 +5758,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
             "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-            "license": "MIT",
             "dependencies": {
                 "get-intrinsic": "^1.1.3"
             },
@@ -6686,27 +5770,23 @@
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "dev": true,
-            "license": "ISC",
             "peer": true
         },
         "node_modules/graphemer": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
             "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/harfbuzzjs": {
             "version": "0.4.3",
             "resolved": "https://registry.npmjs.org/harfbuzzjs/-/harfbuzzjs-0.4.3.tgz",
-            "integrity": "sha512-g7yRM1C7/le3PN9GPNufA3T1PEugOVOrG1WbDZKR0Olx0rft+1VKr0dx9nDcdBOT9vDXtXCH2/5fjc16OvRg5Q==",
-            "license": "MIT"
+            "integrity": "sha512-g7yRM1C7/le3PN9GPNufA3T1PEugOVOrG1WbDZKR0Olx0rft+1VKr0dx9nDcdBOT9vDXtXCH2/5fjc16OvRg5Q=="
         },
         "node_modules/has-bigints": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
             "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
-            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -6716,7 +5796,6 @@
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -6725,7 +5804,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
             "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-            "license": "MIT",
             "dependencies": {
                 "es-define-property": "^1.0.0"
             },
@@ -6737,7 +5815,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
             "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -6749,7 +5826,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
             "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -6761,7 +5837,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
             "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-            "license": "MIT",
             "dependencies": {
                 "has-symbols": "^1.0.3"
             },
@@ -6776,7 +5851,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
             "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-            "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
             },
@@ -6789,7 +5863,6 @@
             "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.3.tgz",
             "integrity": "sha512-M17uBDzMJ9RPCqLMO92gNNUDuBSq10a25SDBI08iCCxmorf4Yy6sYHK57n9WAbRAAaU+DuR4W6GN9K4DFZesYg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0",
                 "@types/unist": "^3.0.0",
@@ -6813,7 +5886,6 @@
             "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
             "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0"
             },
@@ -6826,15 +5898,13 @@
             "version": "5.5.3",
             "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
             "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/html-void-elements": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
             "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -6845,7 +5915,6 @@
             "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
             "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
             "dev": true,
-            "license": "ISC",
             "peer": true
         },
         "node_modules/ieee754": {
@@ -6865,15 +5934,13 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ],
-            "license": "BSD-3-Clause"
+            ]
         },
         "node_modules/ignore": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
             "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 4"
             }
@@ -6883,7 +5950,6 @@
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
             "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
@@ -6900,7 +5966,6 @@
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
             "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.8.19"
             }
@@ -6911,7 +5976,6 @@
             "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
             "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
             "dev": true,
-            "license": "ISC",
             "peer": true,
             "dependencies": {
                 "once": "^1.3.0",
@@ -6923,14 +5987,12 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true,
-            "license": "ISC",
             "peer": true
         },
         "node_modules/internal-slot": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
             "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
-            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "hasown": "^2.0.0",
@@ -6941,16 +6003,14 @@
             }
         },
         "node_modules/inversify": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/inversify/-/inversify-6.0.2.tgz",
-            "integrity": "sha512-i9m8j/7YIv4mDuYXUAcrpKPSaju/CIly9AHK5jvCBeoiM/2KEsuCQTTP+rzSWWpLYWRukdXFSl6ZTk2/uumbiA==",
-            "license": "MIT"
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/inversify/-/inversify-6.0.3.tgz",
+            "integrity": "sha512-s/svzcRQ/scaGUUyaVtFSL1dvOaRgyvE7VvpGcJwXmFz7CCzfSfxC/Uyl7iSHDEmBabJ2gbDES72DaygtMmwvg=="
         },
         "node_modules/is-arguments": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
             "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-            "license": "MIT",
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "has-tostringtag": "^1.0.0"
@@ -6966,10 +6026,25 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
             "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
-            "license": "MIT",
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "get-intrinsic": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-async-function": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.0.0.tgz",
+            "integrity": "sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "has-tostringtag": "^1.0.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -6982,7 +6057,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
             "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
-            "license": "MIT",
             "dependencies": {
                 "has-bigints": "^1.0.1"
             },
@@ -6994,7 +6068,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
             "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
-            "license": "MIT",
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "has-tostringtag": "^1.0.0"
@@ -7010,7 +6083,6 @@
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
             "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -7023,7 +6095,6 @@
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
             "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "hasown": "^2.0.2"
             },
@@ -7039,7 +6110,6 @@
             "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
             "integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "is-typed-array": "^1.1.13"
@@ -7055,7 +6125,6 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
             "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-            "license": "MIT",
             "dependencies": {
                 "has-tostringtag": "^1.0.0"
             },
@@ -7071,9 +6140,37 @@
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-finalizationregistry": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.0.2.tgz",
+            "integrity": "sha512-0by5vtUJs8iFQb5TYUHHPudOR+qXYIMKtiUzvLIZITZUjknFmziyBJuLhVRc+Ds0dREFlskDNJKYIdIzu/9pfw==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "call-bind": "^1.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-generator-function": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+            "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-glob": {
@@ -7081,7 +6178,6 @@
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "is-extglob": "^2.1.1"
             },
@@ -7093,7 +6189,6 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
             "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -7105,15 +6200,13 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
             "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/is-negative-zero": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
             "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">= 0.4"
@@ -7135,7 +6228,6 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
             "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
-            "license": "MIT",
             "dependencies": {
                 "has-tostringtag": "^1.0.0"
             },
@@ -7151,7 +6243,6 @@
             "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
             "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -7161,7 +6252,6 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
             "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-            "license": "MIT",
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "has-tostringtag": "^1.0.0"
@@ -7178,7 +6268,6 @@
             "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
             "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -7188,7 +6277,6 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
             "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -7200,7 +6288,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
             "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
-            "license": "MIT",
             "dependencies": {
                 "call-bind": "^1.0.7"
             },
@@ -7216,7 +6303,6 @@
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
             "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=8"
@@ -7229,7 +6315,6 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
             "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-            "license": "MIT",
             "dependencies": {
                 "has-tostringtag": "^1.0.0"
             },
@@ -7244,7 +6329,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
             "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-            "license": "MIT",
             "dependencies": {
                 "has-symbols": "^1.0.2"
             },
@@ -7260,7 +6344,6 @@
             "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
             "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "which-typed-array": "^1.1.14"
@@ -7276,7 +6359,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
             "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -7289,7 +6371,6 @@
             "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
             "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.2"
@@ -7302,7 +6383,6 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.3.tgz",
             "integrity": "sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==",
-            "license": "MIT",
             "dependencies": {
                 "call-bind": "^1.0.7",
                 "get-intrinsic": "^1.2.4"
@@ -7319,7 +6399,6 @@
             "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
             "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=12.13"
             },
@@ -7330,22 +6409,19 @@
         "node_modules/isarray": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-            "license": "MIT"
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
         },
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-            "dev": true,
-            "license": "ISC"
+            "dev": true
         },
         "node_modules/jake": {
             "version": "10.9.2",
             "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
             "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
             "dev": true,
-            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
                 "async": "^3.2.3",
@@ -7365,7 +6441,6 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -7377,7 +6452,6 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
-            "license": "ISC",
             "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -7389,21 +6463,18 @@
         "node_modules/jpeg-exif": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
-            "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
-            "license": "MIT"
+            "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ=="
         },
         "node_modules/js-base64": {
             "version": "3.7.7",
             "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
-            "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==",
-            "license": "BSD-3-Clause"
+            "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/js-yaml": {
@@ -7411,7 +6482,6 @@
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
             "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -7423,7 +6493,6 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-3.1.3.tgz",
             "integrity": "sha512-Q1PKVMK/uu+yjdlobgWIYkUOCR1SqUmW9m/eUJNNj4zI2N12i25v8fYpVf+zCakQeaTdBdhnZTFbVIAVZIVVOg==",
-            "license": "LGPL-2.1+",
             "engines": {
                 "node": ">=0.1.90"
             }
@@ -7433,7 +6502,6 @@
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
             "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "bin": {
                 "jsesc": "bin/jsesc"
@@ -7446,37 +6514,32 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/json-schema": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
             "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
             "dev": true,
-            "license": "(AFL-2.1 OR BSD-3-Clause)",
             "peer": true
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/json5": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
             "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "bin": {
                 "json5": "lib/cli.js"
@@ -7489,7 +6552,6 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-2.0.5.tgz",
             "integrity": "sha512-wEse9+QLIIU5IaCgtJCPsFi/H4F3qcikWzF4bAELZiRz08ohfx3Q6CjDRf4ZPF5P/92RI3KIHtb7u3jqPaHXdQ==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 8"
             }
@@ -7499,7 +6561,6 @@
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
             "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "universalify": "^2.0.0"
@@ -7513,7 +6574,6 @@
             "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
             "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -7524,7 +6584,6 @@
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
             "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "json-buffer": "3.0.1"
             }
@@ -7534,7 +6593,6 @@
             "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
             "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=6"
@@ -7545,7 +6603,6 @@
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "prelude-ls": "^1.2.1",
                 "type-check": "~0.4.0"
@@ -7558,7 +6615,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
             "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
-            "license": "MIT",
             "dependencies": {
                 "base64-js": "0.0.8",
                 "unicode-trie": "^2.0.0"
@@ -7568,7 +6624,6 @@
             "version": "0.0.8",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
             "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             }
@@ -7578,7 +6633,6 @@
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
             "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "p-locate": "^5.0.0"
             },
@@ -7594,36 +6648,31 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/lodash-es": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-            "license": "MIT"
+            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
         },
         "node_modules/lodash.debounce": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
             "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/lodash.sortby": {
             "version": "4.7.0",
             "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
             "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/lru-cache": {
@@ -7631,17 +6680,15 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
             "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
             "dev": true,
-            "license": "ISC",
             "peer": true,
             "dependencies": {
                 "yallist": "^3.0.2"
             }
         },
         "node_modules/magic-string": {
-            "version": "0.30.12",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.12.tgz",
-            "integrity": "sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==",
-            "license": "MIT",
+            "version": "0.30.13",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.13.tgz",
+            "integrity": "sha512-8rYBO+MsWkgjDSOvLomYnzhdwEG51olQ4zL5KXnNJWV5MNmrb4rTZdrtkhxjnD/QyZUqR/Z/XDsUs/4ej2nx0g==",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0"
             }
@@ -7650,15 +6697,13 @@
             "version": "8.11.1",
             "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
             "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/mdast-util-to-hast": {
             "version": "13.2.0",
             "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
             "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0",
                 "@types/mdast": "^4.0.0",
@@ -7699,7 +6744,6 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
                 "micromark-util-symbol": "^2.0.0",
                 "micromark-util-types": "^2.0.0"
@@ -7719,8 +6763,7 @@
                     "type": "OpenCollective",
                     "url": "https://opencollective.com/unified"
                 }
-            ],
-            "license": "MIT"
+            ]
         },
         "node_modules/micromark-util-sanitize-uri": {
             "version": "2.0.1",
@@ -7737,7 +6780,6 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
                 "micromark-util-character": "^2.0.0",
                 "micromark-util-encode": "^2.0.0",
@@ -7758,8 +6800,7 @@
                     "type": "OpenCollective",
                     "url": "https://opencollective.com/unified"
                 }
-            ],
-            "license": "MIT"
+            ]
         },
         "node_modules/micromark-util-types": {
             "version": "2.0.1",
@@ -7775,8 +6816,7 @@
                     "type": "OpenCollective",
                     "url": "https://opencollective.com/unified"
                 }
-            ],
-            "license": "MIT"
+            ]
         },
         "node_modules/micromatch": {
             "version": "4.0.8",
@@ -7789,33 +6829,6 @@
             },
             "engines": {
                 "node": ">=8.6"
-            }
-        },
-        "node_modules/mime-db": {
-            "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/mime-types": {
-            "version": "2.1.35",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "mime-db": "1.52.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
             }
         },
         "node_modules/minimatch": {
@@ -7834,25 +6847,22 @@
             }
         },
         "node_modules/minisearch": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.1.0.tgz",
-            "integrity": "sha512-tv7c/uefWdEhcu6hvrfTihflgeEi2tN6VV7HJnCjK6VxM75QQJh4t9FwJCsA2EsRS8LCnu3W87CuGPWMocOLCA==",
-            "dev": true,
-            "license": "MIT"
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.1.1.tgz",
+            "integrity": "sha512-b3YZEYCEH4EdCAtYP7OlDyx7FdPwNzuNwLQ34SfJpM9dlbBZzeXndGavTrC+VCiRWomL21SWfMc6SCKO/U2ZNw==",
+            "dev": true
         },
         "node_modules/mitt": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
             "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/monaco-editor": {
             "name": "@codingame/monaco-vscode-editor-api",
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-editor-api/-/monaco-vscode-editor-api-8.0.4.tgz",
             "integrity": "sha512-rKUdFRsnzTV1dj6FL/MD+cBIUAGv9aJNz8bTx4BA5sDK3lDWuifhdCBvk4WZEj6glfXe3sEfGXKy1Vp5btDOJQ==",
-            "license": "MIT",
             "dependencies": {
                 "vscode": "npm:@codingame/monaco-vscode-api@8.0.4"
             }
@@ -7861,7 +6871,6 @@
             "version": "5.5.3",
             "resolved": "https://registry.npmjs.org/monaco-editor-wrapper/-/monaco-editor-wrapper-5.5.3.tgz",
             "integrity": "sha512-ceC+HnpUw/WehfH9uL7Y5j1m/46hQFcS/Z1VYpiFl+pieNf4/JfOWrzLEDqnxOK/qrPJ2fR6JB78mfZNLtPeQQ==",
-            "license": "MIT",
             "dependencies": {
                 "@codingame/monaco-vscode-configuration-service-override": "~8.0.4",
                 "@codingame/monaco-vscode-editor-service-override": "~8.0.4",
@@ -7910,7 +6919,6 @@
             "version": "8.8.3",
             "resolved": "https://registry.npmjs.org/monaco-languageclient/-/monaco-languageclient-8.8.3.tgz",
             "integrity": "sha512-F/ETX2EuUgFnwxNXCrlPOplrINTPMzNvMJBKdl6ZzHnCucnaoJQt9nmqWZmNG4DU2cyaUwTMrcNODOgqQ+So4w==",
-            "license": "MIT",
             "dependencies": {
                 "@codingame/monaco-vscode-extensions-service-override": "~8.0.4",
                 "@codingame/monaco-vscode-languages-service-override": "~8.0.4",
@@ -7941,8 +6949,7 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/nanoid": {
             "version": "3.3.7",
@@ -7954,7 +6961,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -7966,22 +6972,19 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/node-releases": {
             "version": "2.0.18",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
             "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/object-inspect": {
-            "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
-            "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
-            "license": "MIT",
+            "version": "1.13.3",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+            "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -7993,7 +6996,6 @@
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
             "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-            "license": "MIT",
             "dependencies": {
                 "call-bind": "^1.0.7",
                 "define-properties": "^1.2.1"
@@ -8009,7 +7011,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
             "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             }
@@ -8018,7 +7019,6 @@
             "version": "4.1.5",
             "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
             "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
-            "license": "MIT",
             "dependencies": {
                 "call-bind": "^1.0.5",
                 "define-properties": "^1.2.1",
@@ -8037,7 +7037,6 @@
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
             "dev": true,
-            "license": "ISC",
             "peer": true,
             "dependencies": {
                 "wrappy": "1"
@@ -8048,7 +7047,6 @@
             "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-0.4.1.tgz",
             "integrity": "sha512-rNcEohFz095QKGRovP/yqPIKc+nP+Sjs4YTHMv33nMePGKrq/r2eu9Yh4646M5XluGJsUnmwoXuiXE69KDs+fQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "emoji-regex-xs": "^1.0.0",
                 "regex": "^5.0.0",
@@ -8060,7 +7058,6 @@
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
             "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
@@ -8078,7 +7075,6 @@
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
             "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "yocto-queue": "^0.1.0"
             },
@@ -8094,7 +7090,6 @@
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
             "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "p-limit": "^3.0.2"
             },
@@ -8106,17 +7101,15 @@
             }
         },
         "node_modules/pako": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
-            "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
-            "license": "(MIT AND Zlib)"
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+            "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
         },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "callsites": "^3.0.0"
             },
@@ -8129,7 +7122,6 @@
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -8139,7 +7131,6 @@
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -8150,7 +7141,6 @@
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -8159,14 +7149,12 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/pdfkit": {
             "version": "0.15.1",
             "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.15.1.tgz",
             "integrity": "sha512-sleaMQXbQ/Dk+38HlxdiMT6Lmw5+HoNc4vkJR1Tb9XGALuB1xrfdWYbDFta70F3jCrVkhA2DiQ52D7jbysGZrw==",
-            "license": "MIT",
             "dependencies": {
                 "crypto-js": "^4.2.0",
                 "fontkit": "^1.8.1",
@@ -8179,7 +7167,6 @@
             "version": "0.3.17",
             "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.17.tgz",
             "integrity": "sha512-tb7Iu+oZ+zWJZ3HJqwx8oNwSDIU440hmVMDPhpACWQWnrZHK99Bxs70gT1L2dnr5Hg50ZRWEFkQCAnOVVV0z1Q==",
-            "license": "MIT",
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -8188,7 +7175,6 @@
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
             "integrity": "sha512-HkW/8Lrk8jl18kzQHvAw9aTHe1cqsyx5sDnxncx652+CIfhawokEPkeM3BoIC+z/Xv7a0yMr0f3pRRwhGH455g==",
-            "license": "MIT",
             "dependencies": {
                 "@swc/helpers": "^0.3.13",
                 "brotli": "^1.3.2",
@@ -8204,28 +7190,24 @@
         "node_modules/pdfkit/node_modules/restructure": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/restructure/-/restructure-2.0.1.tgz",
-            "integrity": "sha512-e0dOpjm5DseomnXx2M5lpdZ5zoHqF1+bqdMJUohoYVVQa7cBdnk7fdmeI6byNWP/kiME72EeTiSypTCVnpLiDg==",
-            "license": "MIT"
+            "integrity": "sha512-e0dOpjm5DseomnXx2M5lpdZ5zoHqF1+bqdMJUohoYVVQa7cBdnk7fdmeI6byNWP/kiME72EeTiSypTCVnpLiDg=="
         },
         "node_modules/perfect-debounce": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
             "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-            "license": "ISC"
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8.6"
             },
@@ -8242,7 +7224,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
             "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             }
@@ -8265,7 +7246,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
                 "nanoid": "^3.3.7",
                 "picocolors": "^1.1.1",
@@ -8276,11 +7256,10 @@
             }
         },
         "node_modules/preact": {
-            "version": "10.24.2",
-            "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.2.tgz",
-            "integrity": "sha512-1cSoF0aCC8uaARATfrlz4VCBqE8LwZwRfLgkxJOQwAlQt6ayTmi0D9OF7nXid1POI5SZidFuG9CnlXbDfLqY/Q==",
+            "version": "10.25.0",
+            "resolved": "https://registry.npmjs.org/preact/-/preact-10.25.0.tgz",
+            "integrity": "sha512-6bYnzlLxXV3OSpUxLdaxBmE7PMOu0aR3pG6lryK/0jmvcDFPlcXGQAt5DpK3RITWiDrfYZRI0druyaK/S9kYLg==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/preact"
@@ -8291,7 +7270,6 @@
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.8.0"
             }
@@ -8300,7 +7278,6 @@
             "version": "3.3.3",
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
             "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
-            "license": "MIT",
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -8316,7 +7293,6 @@
             "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
             "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "fast-diff": "^1.1.2"
             },
@@ -8329,7 +7305,6 @@
             "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
             "integrity": "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": "^14.13.1 || >=16.0.0"
@@ -8343,27 +7318,16 @@
             "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.5.0.tgz",
             "integrity": "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
-        },
-        "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
         },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
@@ -8393,7 +7357,6 @@
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
             "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "safe-buffer": "^5.1.0"
@@ -8402,15 +7365,35 @@
         "node_modules/reflect-metadata": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
-            "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-            "license": "Apache-2.0"
+            "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="
+        },
+        "node_modules/reflect.getprototypeof": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.6.tgz",
+            "integrity": "sha512-fmfw4XgoDke3kdI6h4xcUz1dG8uaiv5q9gcEwLS4Pnth2kxT+GZ7YehS1JTMGBQmtV7Y4GFGbs2re2NqhdozUg==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "call-bind": "^1.0.7",
+                "define-properties": "^1.2.1",
+                "es-abstract": "^1.23.1",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.4",
+                "globalthis": "^1.0.3",
+                "which-builtin-type": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/regenerate": {
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
             "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/regenerate-unicode-properties": {
@@ -8418,7 +7401,6 @@
             "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.0.tgz",
             "integrity": "sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "regenerate": "^1.4.2"
@@ -8432,7 +7414,6 @@
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
             "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/regenerator-transform": {
@@ -8440,25 +7421,25 @@
             "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
             "integrity": "sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.8.4"
             }
         },
         "node_modules/regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/regex/-/regex-5.0.1.tgz",
-            "integrity": "sha512-gIS00E8eHNWONxofNKOhtlkwBQj/K39ZJamnvMEFH3pNKc06Zz2jtFXF/4ldAaJTzQNhMJU7b5+C7tTq2ukV7Q==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/regex/-/regex-5.0.2.tgz",
+            "integrity": "sha512-/pczGbKIQgfTMRV0XjABvc5RzLqQmwqxLHdQao2RTXPk+pmTXB2P0IaUHYdYyk412YLwUIkaeMd5T+RzVgTqnQ==",
             "dev": true,
-            "license": "MIT"
+            "dependencies": {
+                "regex-utilities": "^2.3.0"
+            }
         },
         "node_modules/regex-recursion": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-4.2.1.tgz",
             "integrity": "sha512-QHNZyZAeKdndD1G3bKAbBEKOSSK4KOHQrAJ01N1LJeb0SoH4DJIeFhp0uUpETgONifS4+P3sOgoA1dhzgrQvhA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "regex-utilities": "^2.3.0"
             }
@@ -8467,14 +7448,12 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
             "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/regexp.prototype.flags": {
             "version": "1.5.3",
             "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.3.tgz",
             "integrity": "sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==",
-            "license": "MIT",
             "dependencies": {
                 "call-bind": "^1.0.7",
                 "define-properties": "^1.2.1",
@@ -8489,17 +7468,16 @@
             }
         },
         "node_modules/regexpu-core": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.1.1.tgz",
-            "integrity": "sha512-k67Nb9jvwJcJmVpw0jPttR1/zVfnKf8Km0IPatrU/zJ5XeG3+Slx0xLXs9HByJSzXzrlz5EDvN6yLNMDc2qdnw==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.2.0.tgz",
+            "integrity": "sha512-H66BPQMrv+V16t8xtmq+UC0CBpiTBA60V8ibS1QVReIp8T1z8hwFxqcGzm9K6lgsN7sB5edVH8a+ze6Fqm4weA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "regenerate": "^1.4.2",
                 "regenerate-unicode-properties": "^10.2.0",
                 "regjsgen": "^0.8.0",
-                "regjsparser": "^0.11.0",
+                "regjsparser": "^0.12.0",
                 "unicode-match-property-ecmascript": "^2.0.0",
                 "unicode-match-property-value-ecmascript": "^2.1.0"
             },
@@ -8512,15 +7490,13 @@
             "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
             "integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/regjsparser": {
-            "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.11.1.tgz",
-            "integrity": "sha512-1DHODs4B8p/mQHU9kr+jv8+wIC9mtG4eBHxWxIq5mhjE3D5oORhCc6deRKzTjs9DcfRFmj9BHSDguZklqCGFWQ==",
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.12.0.tgz",
+            "integrity": "sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "peer": true,
             "dependencies": {
                 "jsesc": "~3.0.2"
@@ -8534,7 +7510,6 @@
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -8545,7 +7520,6 @@
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
             "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "is-core-module": "^2.13.0",
                 "path-parse": "^1.0.7",
@@ -8563,7 +7537,6 @@
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=4"
             }
@@ -8571,8 +7544,7 @@
         "node_modules/restructure": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
-            "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
-            "license": "MIT"
+            "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw=="
         },
         "node_modules/reusify": {
             "version": "1.0.4",
@@ -8588,15 +7560,13 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
             "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/rollup": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.0.tgz",
-            "integrity": "sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==",
+            "version": "4.27.3",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.27.3.tgz",
+            "integrity": "sha512-SLsCOnlmGt9VoZ9Ek8yBK8tAdmPHeppkw+Xa7yDlCEhDTvwYei03JlWo1fdc7YTfLZ4tD8riJCUyAgTbszk1fQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/estree": "1.0.6"
             },
@@ -8608,22 +7578,24 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.24.0",
-                "@rollup/rollup-android-arm64": "4.24.0",
-                "@rollup/rollup-darwin-arm64": "4.24.0",
-                "@rollup/rollup-darwin-x64": "4.24.0",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.24.0",
-                "@rollup/rollup-linux-arm-musleabihf": "4.24.0",
-                "@rollup/rollup-linux-arm64-gnu": "4.24.0",
-                "@rollup/rollup-linux-arm64-musl": "4.24.0",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.24.0",
-                "@rollup/rollup-linux-riscv64-gnu": "4.24.0",
-                "@rollup/rollup-linux-s390x-gnu": "4.24.0",
-                "@rollup/rollup-linux-x64-gnu": "4.24.0",
-                "@rollup/rollup-linux-x64-musl": "4.24.0",
-                "@rollup/rollup-win32-arm64-msvc": "4.24.0",
-                "@rollup/rollup-win32-ia32-msvc": "4.24.0",
-                "@rollup/rollup-win32-x64-msvc": "4.24.0",
+                "@rollup/rollup-android-arm-eabi": "4.27.3",
+                "@rollup/rollup-android-arm64": "4.27.3",
+                "@rollup/rollup-darwin-arm64": "4.27.3",
+                "@rollup/rollup-darwin-x64": "4.27.3",
+                "@rollup/rollup-freebsd-arm64": "4.27.3",
+                "@rollup/rollup-freebsd-x64": "4.27.3",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.27.3",
+                "@rollup/rollup-linux-arm-musleabihf": "4.27.3",
+                "@rollup/rollup-linux-arm64-gnu": "4.27.3",
+                "@rollup/rollup-linux-arm64-musl": "4.27.3",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.27.3",
+                "@rollup/rollup-linux-riscv64-gnu": "4.27.3",
+                "@rollup/rollup-linux-s390x-gnu": "4.27.3",
+                "@rollup/rollup-linux-x64-gnu": "4.27.3",
+                "@rollup/rollup-linux-x64-musl": "4.27.3",
+                "@rollup/rollup-win32-arm64-msvc": "4.27.3",
+                "@rollup/rollup-win32-ia32-msvc": "4.27.3",
+                "@rollup/rollup-win32-x64-msvc": "4.27.3",
                 "fsevents": "~2.3.2"
             }
         },
@@ -8655,7 +7627,6 @@
             "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
             "integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.7",
@@ -8689,7 +7660,6 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "MIT",
             "peer": true
         },
         "node_modules/safe-regex-test": {
@@ -8697,7 +7667,6 @@
             "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
             "integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.6",
@@ -8712,18 +7681,16 @@
             }
         },
         "node_modules/search-insights": {
-            "version": "2.17.2",
-            "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.2.tgz",
-            "integrity": "sha512-zFNpOpUO+tY2D85KrxJ+aqwnIfdEGi06UH2+xEb+Bp9Mwznmauqc9djbnBibJO5mpfUPPa8st6Sx65+vbeO45g==",
+            "version": "2.17.3",
+            "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+            "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/semver": {
             "version": "7.6.3",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
             "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-            "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -8736,7 +7703,6 @@
             "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
             "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "peer": true,
             "dependencies": {
                 "randombytes": "^2.1.0"
@@ -8746,7 +7712,6 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
             "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-            "license": "MIT",
             "dependencies": {
                 "define-data-property": "^1.1.4",
                 "es-errors": "^1.3.0",
@@ -8763,7 +7728,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
             "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
-            "license": "MIT",
             "dependencies": {
                 "define-data-property": "^1.1.4",
                 "es-errors": "^1.3.0",
@@ -8779,7 +7743,6 @@
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "shebang-regex": "^3.0.0"
             },
@@ -8792,7 +7755,6 @@
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -8802,7 +7764,6 @@
             "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.23.1.tgz",
             "integrity": "sha512-8kxV9TH4pXgdKGxNOkrSMydn1Xf6It8lsle0fiqxf7a1149K1WGtdOu3Zb91T5r1JpvRPxqxU3C2XdZZXQnrig==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@shikijs/core": "1.23.1",
                 "@shikijs/engine-javascript": "1.23.1",
@@ -8816,7 +7777,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
             "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
-            "license": "MIT",
             "dependencies": {
                 "call-bind": "^1.0.7",
                 "es-errors": "^1.3.0",
@@ -8835,14 +7795,12 @@
             "resolved": "https://registry.npmjs.org/smob/-/smob-1.5.0.tgz",
             "integrity": "sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/snabbdom": {
             "version": "3.5.1",
             "resolved": "https://registry.npmjs.org/snabbdom/-/snabbdom-3.5.1.tgz",
             "integrity": "sha512-wHMNIOjkm/YNE5EM3RCbr/+DVgPg6AqQAX1eOxO46zYNvCXjKP5Y865tqQj3EXnaMBjkxmQA5jFuDpDK/dbfiA==",
-            "license": "MIT",
             "engines": {
                 "node": ">=8.3.0"
             }
@@ -8852,7 +7810,6 @@
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
             "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "peer": true,
             "dependencies": {
                 "whatwg-url": "^7.0.0"
@@ -8865,7 +7822,6 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
             "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -8875,7 +7831,6 @@
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
             "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "buffer-from": "^1.0.0",
@@ -8887,7 +7842,6 @@
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "peer": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -8899,7 +7853,6 @@
             "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
             "deprecated": "Please use @jridgewell/sourcemap-codec instead",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/space-separated-tokens": {
@@ -8907,7 +7860,6 @@
             "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
             "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -8918,7 +7870,6 @@
             "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
             "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -8927,7 +7878,6 @@
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/splitpanes/-/splitpanes-3.1.5.tgz",
             "integrity": "sha512-r3Mq2ITFQ5a2VXLOy4/Sb2Ptp7OfEO8YIbhVJqJXoFc9hc5nTXXkCvtVDjIGbvC0vdE7tse+xTM9BMjsszP6bw==",
-            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/antoniandre"
             }
@@ -8935,14 +7885,12 @@
         "node_modules/sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-            "license": "BSD-3-Clause"
+            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
         },
         "node_modules/sprotty": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/sprotty/-/sprotty-1.3.0.tgz",
             "integrity": "sha512-CFGq5po1FsQaCXx/QZjoCFYbwCrEofxAWLjxN3fJqeNmGF+CiRkHgHgXdO0OJq0o1XRgfq9ksAzYZ8Yof4Q3JA==",
-            "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
             "dependencies": {
                 "autocompleter": "^9.1.2",
                 "file-saver": "^2.0.5",
@@ -8955,14 +7903,12 @@
         "node_modules/sprotty-protocol": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/sprotty-protocol/-/sprotty-protocol-1.3.0.tgz",
-            "integrity": "sha512-cQgKHgzVRJXbosvMsEZK4YiMSPOFhL1yYa3oLBzp9lgDL7ltYbdGCQcFqoVD6h56ObuVWyjNZu1R8YSryEkZrg==",
-            "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)"
+            "integrity": "sha512-cQgKHgzVRJXbosvMsEZK4YiMSPOFhL1yYa3oLBzp9lgDL7ltYbdGCQcFqoVD6h56ObuVWyjNZu1R8YSryEkZrg=="
         },
         "node_modules/stop-iteration-iterator": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
             "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
-            "license": "MIT",
             "dependencies": {
                 "internal-slot": "^1.0.4"
             },
@@ -8975,7 +7921,6 @@
             "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.11.tgz",
             "integrity": "sha512-NUdh0aDavY2og7IbBPenWqR9exH+E26Sv8e0/eTe1tltDGZL+GtBkDAnnyBtmekfK6/Dq3MkcGtzXFEd1LQrtg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.7",
@@ -9003,7 +7948,6 @@
             "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
             "integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.7",
@@ -9023,7 +7967,6 @@
             "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
             "integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.7",
@@ -9039,7 +7982,6 @@
             "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
             "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.7",
@@ -9058,7 +8000,6 @@
             "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
             "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "character-entities-html4": "^2.0.0",
                 "character-entities-legacy": "^3.0.0"
@@ -9073,7 +8014,6 @@
             "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
             "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "peer": true,
             "dependencies": {
                 "get-own-enumerable-property-symbols": "^3.0.0",
@@ -9089,7 +8029,6 @@
             "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
             "integrity": "sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=10"
@@ -9100,7 +8039,6 @@
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             },
@@ -9113,7 +8051,6 @@
             "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.1.tgz",
             "integrity": "sha512-8iGv75BYOa0xRJHK5vRLEjE2H/i4lulTjzpUXic3Eg8akftYjkmQDa8JARQ42rlczXyFR3IeRoeFCc7RxHsYZA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "copy-anything": "^3.0.2"
             },
@@ -9126,7 +8063,6 @@
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -9139,7 +8075,6 @@
             "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
             "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -9151,7 +8086,6 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/svgpath/-/svgpath-2.6.0.tgz",
             "integrity": "sha512-OIWR6bKzXvdXYyO4DK/UWa1VA1JeKq8E+0ug2DG98Y/vOmMpfZNj+TIG988HjfYSqtcy/hFOtZq/n/j5GSESNg==",
-            "license": "MIT",
             "funding": {
                 "url": "https://github.com/fontello/svg2ttf?sponsor=1"
             }
@@ -9161,7 +8095,6 @@
             "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.2.tgz",
             "integrity": "sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@pkgr/core": "^0.1.0",
                 "tslib": "^2.6.2"
@@ -9177,15 +8110,13 @@
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
             "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/temp-dir": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
             "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=8"
@@ -9196,7 +8127,6 @@
             "resolved": "https://registry.npmjs.org/tempy/-/tempy-0.6.0.tgz",
             "integrity": "sha512-G13vtMYPT/J8A4X2SjdtBTphZlrp1gKv6hZiOjw14RCWg6GbHuQBGtjlx75xLbYV/wEc0D7G5K4rxKP/cXk8Bw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "is-stream": "^2.0.0",
@@ -9212,11 +8142,10 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.34.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.34.1.tgz",
-            "integrity": "sha512-FsJZ7iZLd/BXkz+4xrRTGJ26o/6VTjQytUk8b8OxkwcD2I+79VPJlz7qss1+zE7h8GNIScFqXcDyJ/KqBYZFVA==",
+            "version": "5.36.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.36.0.tgz",
+            "integrity": "sha512-IYV9eNMuFAV4THUspIRXkLakHnV6XO7FEdtKjf/mDyrnqUg9LnlOn6/RwRvM9SZjR4GUq8Nk8zj67FzVARr74w==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "peer": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
@@ -9231,29 +8160,19 @@
                 "node": ">=10"
             }
         },
-        "node_modules/terser/node_modules/commander": {
-            "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/tiny-inflate": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
-            "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
-            "license": "MIT"
+            "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.9",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.9.tgz",
-            "integrity": "sha512-8or1+BGEdk1Zkkw2ii16qSS7uVrQJPre5A9o/XkWPATkk23FZh/15BKFxPnlTy6vkljZxLqYCzzBMj30ZrSvjw==",
+            "version": "0.2.10",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.10.tgz",
+            "integrity": "sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "fdir": "^6.4.0",
+                "fdir": "^6.4.2",
                 "picomatch": "^4.0.2"
             },
             "engines": {
@@ -9261,11 +8180,10 @@
             }
         },
         "node_modules/tinyglobby/node_modules/fdir": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.0.tgz",
-            "integrity": "sha512-3oB133prH1o4j/L5lLW7uOCF1PlD+/It2L0eL/iAqWMB91RBbqTewABqxhj0ibBd90EEmWZq7ntIWzVaWcXTGQ==",
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
+            "integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "peerDependencies": {
                 "picomatch": "^3 || ^4"
@@ -9281,7 +8199,6 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
             "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=12"
@@ -9293,17 +8210,7 @@
         "node_modules/tinyqueue": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
-            "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
-            "license": "ISC"
-        },
-        "node_modules/to-fast-properties": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-            "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
+            "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
@@ -9322,7 +8229,6 @@
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
             "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "punycode": "^2.1.0"
@@ -9332,7 +8238,6 @@
             "version": "2.16.1",
             "resolved": "https://registry.npmjs.org/transformation-matrix/-/transformation-matrix-2.16.1.tgz",
             "integrity": "sha512-tdtC3wxVEuzU7X/ydL131Q3JU5cPMEn37oqVLITjRDSDsnSHVFzW2JiCLfZLIQEgWzZHdSy3J6bZzvKEN24jGA==",
-            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/chrvadala"
             }
@@ -9342,18 +8247,16 @@
             "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
             "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/ts-api-utils": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
-            "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.0.tgz",
+            "integrity": "sha512-032cPxaEKwM+GT3vA5JXNzIaizx388rhsSW79vGRNGXfRRAdEAn2mvk36PvK5HnOchyWZ7afLEXqYCvPCrzuzQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=16"
             },
@@ -9362,17 +8265,15 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-            "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-            "license": "0BSD"
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
         "node_modules/type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "prelude-ls": "^1.2.1"
             },
@@ -9385,7 +8286,6 @@
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
             "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
             "dev": true,
-            "license": "(MIT OR CC0-1.0)",
             "peer": true,
             "engines": {
                 "node": ">=10"
@@ -9399,7 +8299,6 @@
             "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
             "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.7",
@@ -9415,7 +8314,6 @@
             "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
             "integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.7",
@@ -9432,11 +8330,10 @@
             }
         },
         "node_modules/typed-array-byte-offset": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
-            "integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.3.tgz",
+            "integrity": "sha512-GsvTyUHTriq6o/bHcTd0vM7OQ9JEdlvluu9YISaA7+KzDzPaIzEeDFNkTfhdE3MYcNhNi0vq/LlegYgIs5yPAw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "available-typed-arrays": "^1.0.7",
@@ -9444,7 +8341,8 @@
                 "for-each": "^0.3.3",
                 "gopd": "^1.0.1",
                 "has-proto": "^1.0.3",
-                "is-typed-array": "^1.1.13"
+                "is-typed-array": "^1.1.13",
+                "reflect.getprototypeof": "^1.0.6"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -9458,7 +8356,6 @@
             "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.6.tgz",
             "integrity": "sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.7",
@@ -9480,7 +8377,6 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
             "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
             "devOptional": true,
-            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -9520,7 +8416,6 @@
             "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
             "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
@@ -9536,15 +8431,13 @@
             "version": "6.19.8",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
             "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
             "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=4"
@@ -9555,7 +8448,6 @@
             "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
             "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "unicode-canonical-property-names-ecmascript": "^2.0.0",
@@ -9570,7 +8462,6 @@
             "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.0.tgz",
             "integrity": "sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=4"
@@ -9580,7 +8471,6 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
             "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
-            "license": "MIT",
             "dependencies": {
                 "base64-js": "^1.3.0",
                 "unicode-trie": "^2.0.0"
@@ -9591,7 +8481,6 @@
             "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
             "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=4"
@@ -9601,24 +8490,16 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
             "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
-            "license": "MIT",
             "dependencies": {
                 "pako": "^0.2.5",
                 "tiny-inflate": "^1.0.0"
             }
-        },
-        "node_modules/unicode-trie/node_modules/pako": {
-            "version": "0.2.9",
-            "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-            "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
-            "license": "MIT"
         },
         "node_modules/unique-string": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
             "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "crypto-random-string": "^2.0.0"
@@ -9632,7 +8513,6 @@
             "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
             "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0"
             },
@@ -9646,7 +8526,6 @@
             "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
             "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0"
             },
@@ -9660,7 +8539,6 @@
             "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
             "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0"
             },
@@ -9674,7 +8552,6 @@
             "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
             "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0",
                 "unist-util-is": "^6.0.0",
@@ -9690,7 +8567,6 @@
             "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
             "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0",
                 "unist-util-is": "^6.0.0"
@@ -9705,7 +8581,6 @@
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
             "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
@@ -9716,7 +8591,6 @@
             "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
             "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=4",
@@ -9742,7 +8616,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "escalade": "^3.2.0",
@@ -9760,7 +8633,6 @@
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "dependencies": {
                 "punycode": "^2.1.0"
             }
@@ -9773,7 +8645,6 @@
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"
             ],
-            "license": "MIT",
             "bin": {
                 "uuid": "dist/esm/bin/uuid"
             }
@@ -9783,7 +8654,6 @@
             "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
             "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0",
                 "vfile-message": "^4.0.0"
@@ -9798,7 +8668,6 @@
             "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
             "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0",
                 "unist-util-stringify-position": "^4.0.0"
@@ -9813,7 +8682,6 @@
             "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
             "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.21.3",
                 "postcss": "^8.4.43",
@@ -9869,18 +8737,17 @@
             }
         },
         "node_modules/vite-plugin-pwa": {
-            "version": "0.20.5",
-            "resolved": "https://registry.npmjs.org/vite-plugin-pwa/-/vite-plugin-pwa-0.20.5.tgz",
-            "integrity": "sha512-aweuI/6G6n4C5Inn0vwHumElU/UEpNuO+9iZzwPZGTCH87TeZ6YFMrEY6ZUBQdIHHlhTsbMDryFARcSuOdsz9Q==",
+            "version": "0.21.0",
+            "resolved": "https://registry.npmjs.org/vite-plugin-pwa/-/vite-plugin-pwa-0.21.0.tgz",
+            "integrity": "sha512-gnDE5sN2hdxA4vTl0pe6PCTPXqChk175jH8dZVVTBjFhWarZZoXaAdoTIKCIa8Zbx94sC0CnCOyERBWpxvry+g==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "debug": "^4.3.6",
                 "pretty-bytes": "^6.1.1",
-                "tinyglobby": "^0.2.0",
-                "workbox-build": "^7.1.0",
-                "workbox-window": "^7.1.0"
+                "tinyglobby": "^0.2.10",
+                "workbox-build": "^7.3.0",
+                "workbox-window": "^7.3.0"
             },
             "engines": {
                 "node": ">=16.0.0"
@@ -9891,8 +8758,8 @@
             "peerDependencies": {
                 "@vite-pwa/assets-generator": "^0.2.6",
                 "vite": "^3.1.0 || ^4.0.0 || ^5.0.0",
-                "workbox-build": "^7.1.0",
-                "workbox-window": "^7.1.0"
+                "workbox-build": "^7.3.0",
+                "workbox-window": "^7.3.0"
             },
             "peerDependenciesMeta": {
                 "@vite-pwa/assets-generator": {
@@ -9905,7 +8772,6 @@
             "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.5.0.tgz",
             "integrity": "sha512-q4Q/G2zjvynvizdB3/bupdYkCJe2umSAMv9Ju4d92E6/NXJ59z70xB0q5p/4lpRyAwflDsbwy1mLV9Q5+nlB+g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@docsearch/css": "^3.6.2",
                 "@docsearch/js": "^3.6.2",
@@ -9947,7 +8813,6 @@
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-8.0.4.tgz",
             "integrity": "sha512-qZ+HwIijDvzwwWscMA73y9ARu5zUaENOdzi0jQftJP9j2k96cRghsaCV25OgnmpZ/1BemjB4HhHCcr71Gq+GPQ==",
-            "license": "MIT",
             "dependencies": {
                 "@codingame/monaco-vscode-base-service-override": "8.0.4",
                 "@codingame/monaco-vscode-environment-service-override": "8.0.4",
@@ -9964,7 +8829,6 @@
             "version": "8.2.0",
             "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
             "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
-            "license": "MIT",
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -9973,7 +8837,6 @@
             "version": "9.0.1",
             "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
             "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
-            "license": "MIT",
             "dependencies": {
                 "minimatch": "^5.1.0",
                 "semver": "^7.3.7",
@@ -9987,7 +8850,6 @@
             "version": "5.1.6",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
             "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
@@ -9999,7 +8861,6 @@
             "version": "9.0.1",
             "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
             "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
-            "license": "MIT",
             "dependencies": {
                 "vscode-languageserver-protocol": "3.17.5"
             },
@@ -10011,7 +8872,6 @@
             "version": "3.17.5",
             "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
             "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
-            "license": "MIT",
             "dependencies": {
                 "vscode-jsonrpc": "8.2.0",
                 "vscode-languageserver-types": "3.17.5"
@@ -10020,32 +8880,27 @@
         "node_modules/vscode-languageserver-textdocument": {
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-            "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
-            "license": "MIT"
+            "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="
         },
         "node_modules/vscode-languageserver-types": {
             "version": "3.17.5",
             "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-            "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
-            "license": "MIT"
+            "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
         },
         "node_modules/vscode-oniguruma": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
-            "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
-            "license": "MIT"
+            "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA=="
         },
         "node_modules/vscode-textmate": {
             "version": "9.0.0",
             "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-9.0.0.tgz",
-            "integrity": "sha512-Cl65diFGxz7gpwbav10HqiY/eVYTO1sjQpmRmV991Bj7wAoOAjGQ97PpQcXorDE2Uc4hnGWLY17xme+5t6MlSg==",
-            "license": "MIT"
+            "integrity": "sha512-Cl65diFGxz7gpwbav10HqiY/eVYTO1sjQpmRmV991Bj7wAoOAjGQ97PpQcXorDE2Uc4hnGWLY17xme+5t6MlSg=="
         },
         "node_modules/vscode-ws-jsonrpc": {
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/vscode-ws-jsonrpc/-/vscode-ws-jsonrpc-3.3.2.tgz",
             "integrity": "sha512-jxGHxAuow67sNRkkS2svsW00ZACX+Zrbury9Au2A22px6sg4pe858Nnnwvtg0Pm4D0L/W9Yzn7N7X3R/RIMxsQ==",
-            "license": "MIT",
             "dependencies": {
                 "vscode-jsonrpc": "~8.2.1"
             },
@@ -10058,7 +8913,6 @@
             "version": "8.2.1",
             "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
             "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
-            "license": "MIT",
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -10067,7 +8921,6 @@
             "version": "3.5.13",
             "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.13.tgz",
             "integrity": "sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==",
-            "license": "MIT",
             "dependencies": {
                 "@vue/compiler-dom": "3.5.13",
                 "@vue/compiler-sfc": "3.5.13",
@@ -10089,7 +8942,6 @@
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
             "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "peer": true
         },
         "node_modules/website": {
@@ -10101,7 +8953,6 @@
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
             "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "lodash.sortby": "^4.7.0",
@@ -10114,7 +8965,6 @@
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -10129,7 +8979,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
             "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-            "license": "MIT",
             "dependencies": {
                 "is-bigint": "^1.0.1",
                 "is-boolean-object": "^1.1.0",
@@ -10141,11 +8990,37 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/which-builtin-type": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.1.4.tgz",
+            "integrity": "sha512-bppkmBSsHFmIMSl8BO9TbsyzsvGjVoppt8xUiGzwiu/bhDCGxnpOKCxgqj6GuyHE0mINMDecBFPlOm2hzY084w==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "function.prototype.name": "^1.1.6",
+                "has-tostringtag": "^1.0.2",
+                "is-async-function": "^2.0.0",
+                "is-date-object": "^1.0.5",
+                "is-finalizationregistry": "^1.0.2",
+                "is-generator-function": "^1.0.10",
+                "is-regex": "^1.1.4",
+                "is-weakref": "^1.0.2",
+                "isarray": "^2.0.5",
+                "which-boxed-primitive": "^1.0.2",
+                "which-collection": "^1.0.2",
+                "which-typed-array": "^1.1.15"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/which-collection": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
             "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
-            "license": "MIT",
             "dependencies": {
                 "is-map": "^2.0.3",
                 "is-set": "^2.0.3",
@@ -10163,7 +9038,6 @@
             "version": "1.1.15",
             "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
             "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
-            "license": "MIT",
             "dependencies": {
                 "available-typed-arrays": "^1.0.7",
                 "call-bind": "^1.0.7",
@@ -10183,40 +9057,36 @@
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
             "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/workbox-background-sync": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-7.1.0.tgz",
-            "integrity": "sha512-rMbgrzueVWDFcEq1610YyDW71z0oAXLfdRHRQcKw4SGihkfOK0JUEvqWHFwA6rJ+6TClnMIn7KQI5PNN1XQXwQ==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-7.3.0.tgz",
+            "integrity": "sha512-PCSk3eK7Mxeuyatb22pcSx9dlgWNv3+M8PqPaYDokks8Y5/FX4soaOqj3yhAZr5k6Q5JWTOMYgaJBpbw11G9Eg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "idb": "^7.0.1",
-                "workbox-core": "7.1.0"
+                "workbox-core": "7.3.0"
             }
         },
         "node_modules/workbox-broadcast-update": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-7.1.0.tgz",
-            "integrity": "sha512-O36hIfhjej/c5ar95pO67k1GQw0/bw5tKP7CERNgK+JdxBANQhDmIuOXZTNvwb2IHBx9hj2kxvcDyRIh5nzOgQ==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-7.3.0.tgz",
+            "integrity": "sha512-T9/F5VEdJVhwmrIAE+E/kq5at2OY6+OXXgOWQevnubal6sO92Gjo24v6dCVwQiclAF5NS3hlmsifRrpQzZCdUA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "workbox-core": "7.1.0"
+                "workbox-core": "7.3.0"
             }
         },
         "node_modules/workbox-build": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-7.1.1.tgz",
-            "integrity": "sha512-WdkVdC70VMpf5NBCtNbiwdSZeKVuhTEd5PV3mAwpTQCGAB5XbOny1P9egEgNdetv4srAMmMKjvBk4RD58LpooA==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-7.3.0.tgz",
+            "integrity": "sha512-JGL6vZTPlxnlqZRhR/K/msqg3wKP+m0wfEUVosK7gsYzSgeIxvZLi1ViJJzVL7CEeI8r7rGFV973RiEqkP3lWQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@apideck/better-ajv-errors": "^0.3.1",
@@ -10241,21 +9111,21 @@
                 "strip-comments": "^2.0.1",
                 "tempy": "^0.6.0",
                 "upath": "^1.2.0",
-                "workbox-background-sync": "7.1.0",
-                "workbox-broadcast-update": "7.1.0",
-                "workbox-cacheable-response": "7.1.0",
-                "workbox-core": "7.1.0",
-                "workbox-expiration": "7.1.0",
-                "workbox-google-analytics": "7.1.0",
-                "workbox-navigation-preload": "7.1.0",
-                "workbox-precaching": "7.1.0",
-                "workbox-range-requests": "7.1.0",
-                "workbox-recipes": "7.1.0",
-                "workbox-routing": "7.1.0",
-                "workbox-strategies": "7.1.0",
-                "workbox-streams": "7.1.0",
-                "workbox-sw": "7.1.0",
-                "workbox-window": "7.1.0"
+                "workbox-background-sync": "7.3.0",
+                "workbox-broadcast-update": "7.3.0",
+                "workbox-cacheable-response": "7.3.0",
+                "workbox-core": "7.3.0",
+                "workbox-expiration": "7.3.0",
+                "workbox-google-analytics": "7.3.0",
+                "workbox-navigation-preload": "7.3.0",
+                "workbox-precaching": "7.3.0",
+                "workbox-range-requests": "7.3.0",
+                "workbox-recipes": "7.3.0",
+                "workbox-routing": "7.3.0",
+                "workbox-strategies": "7.3.0",
+                "workbox-streams": "7.3.0",
+                "workbox-sw": "7.3.0",
+                "workbox-window": "7.3.0"
             },
             "engines": {
                 "node": ">=16.0.0"
@@ -10266,7 +9136,6 @@
             "resolved": "https://registry.npmjs.org/@apideck/better-ajv-errors/-/better-ajv-errors-0.3.6.tgz",
             "integrity": "sha512-P+ZygBLZtkp0qqOAJJVX4oX/sFo5JR3eBWwwuqHHhK0GIgQOKWrAfiAaWX0aArHkRWHMuggFEgAZNxVPwPZYaA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "json-schema": "^0.4.0",
@@ -10285,7 +9154,6 @@
             "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
             "integrity": "sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.10.4",
@@ -10310,7 +9178,6 @@
             "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.4.2.tgz",
             "integrity": "sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@rollup/pluginutils": "^3.1.0",
@@ -10325,7 +9192,6 @@
             "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
             "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@types/estree": "0.0.39",
@@ -10344,7 +9210,6 @@
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
             "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/workbox-build/node_modules/ajv": {
@@ -10352,7 +9217,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -10370,7 +9234,6 @@
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
             "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/workbox-build/node_modules/json-schema-traverse": {
@@ -10378,7 +9241,6 @@
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/workbox-build/node_modules/magic-string": {
@@ -10386,7 +9248,6 @@
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
             "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "sourcemap-codec": "^1.4.8"
@@ -10397,7 +9258,6 @@
             "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
             "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=6"
@@ -10411,7 +9271,6 @@
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
             "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "bin": {
                 "rollup": "dist/bin/rollup"
@@ -10424,153 +9283,140 @@
             }
         },
         "node_modules/workbox-cacheable-response": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-7.1.0.tgz",
-            "integrity": "sha512-iwsLBll8Hvua3xCuBB9h92+/e0wdsmSVgR2ZlvcfjepZWwhd3osumQB3x9o7flj+FehtWM2VHbZn8UJeBXXo6Q==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-7.3.0.tgz",
+            "integrity": "sha512-eAFERIg6J2LuyELhLlmeRcJFa5e16Mj8kL2yCDbhWE+HUun9skRQrGIFVUagqWj4DMaaPSMWfAolM7XZZxNmxA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "workbox-core": "7.1.0"
+                "workbox-core": "7.3.0"
             }
         },
         "node_modules/workbox-core": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-7.1.0.tgz",
-            "integrity": "sha512-5KB4KOY8rtL31nEF7BfvU7FMzKT4B5TkbYa2tzkS+Peqj0gayMT9SytSFtNzlrvMaWgv6y/yvP9C0IbpFjV30Q==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-7.3.0.tgz",
+            "integrity": "sha512-Z+mYrErfh4t3zi7NVTvOuACB0A/jA3bgxUN3PwtAVHvfEsZxV9Iju580VEETug3zYJRc0Dmii/aixI/Uxj8fmw==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/workbox-expiration": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-7.1.0.tgz",
-            "integrity": "sha512-m5DcMY+A63rJlPTbbBNtpJ20i3enkyOtSgYfv/l8h+D6YbbNiA0zKEkCUaMsdDlxggla1oOfRkyqTvl5Ni5KQQ==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-7.3.0.tgz",
+            "integrity": "sha512-lpnSSLp2BM+K6bgFCWc5bS1LR5pAwDWbcKt1iL87/eTSJRdLdAwGQznZE+1czLgn/X05YChsrEegTNxjM067vQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "idb": "^7.0.1",
-                "workbox-core": "7.1.0"
+                "workbox-core": "7.3.0"
             }
         },
         "node_modules/workbox-google-analytics": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-7.1.0.tgz",
-            "integrity": "sha512-FvE53kBQHfVTcZyczeBVRexhh7JTkyQ8HAvbVY6mXd2n2A7Oyz/9fIwnY406ZcDhvE4NFfKGjW56N4gBiqkrew==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-7.3.0.tgz",
+            "integrity": "sha512-ii/tSfFdhjLHZ2BrYgFNTrb/yk04pw2hasgbM70jpZfLk0vdJAXgaiMAWsoE+wfJDNWoZmBYY0hMVI0v5wWDbg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "workbox-background-sync": "7.1.0",
-                "workbox-core": "7.1.0",
-                "workbox-routing": "7.1.0",
-                "workbox-strategies": "7.1.0"
+                "workbox-background-sync": "7.3.0",
+                "workbox-core": "7.3.0",
+                "workbox-routing": "7.3.0",
+                "workbox-strategies": "7.3.0"
             }
         },
         "node_modules/workbox-navigation-preload": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-7.1.0.tgz",
-            "integrity": "sha512-4wyAbo0vNI/X0uWNJhCMKxnPanNyhybsReMGN9QUpaePLTiDpKxPqFxl4oUmBNddPwIXug01eTSLVIFXimRG/A==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-7.3.0.tgz",
+            "integrity": "sha512-fTJzogmFaTv4bShZ6aA7Bfj4Cewaq5rp30qcxl2iYM45YD79rKIhvzNHiFj1P+u5ZZldroqhASXwwoyusnr2cg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "workbox-core": "7.1.0"
+                "workbox-core": "7.3.0"
             }
         },
         "node_modules/workbox-precaching": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-7.1.0.tgz",
-            "integrity": "sha512-LyxzQts+UEpgtmfnolo0hHdNjoB7EoRWcF7EDslt+lQGd0lW4iTvvSe3v5JiIckQSB5KTW5xiCqjFviRKPj1zA==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-7.3.0.tgz",
+            "integrity": "sha512-ckp/3t0msgXclVAYaNndAGeAoWQUv7Rwc4fdhWL69CCAb2UHo3Cef0KIUctqfQj1p8h6aGyz3w8Cy3Ihq9OmIw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "workbox-core": "7.1.0",
-                "workbox-routing": "7.1.0",
-                "workbox-strategies": "7.1.0"
+                "workbox-core": "7.3.0",
+                "workbox-routing": "7.3.0",
+                "workbox-strategies": "7.3.0"
             }
         },
         "node_modules/workbox-range-requests": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-7.1.0.tgz",
-            "integrity": "sha512-m7+O4EHolNs5yb/79CrnwPR/g/PRzMFYEdo01LqwixVnc/sbzNSvKz0d04OE3aMRel1CwAAZQheRsqGDwATgPQ==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-7.3.0.tgz",
+            "integrity": "sha512-EyFmM1KpDzzAouNF3+EWa15yDEenwxoeXu9bgxOEYnFfCxns7eAxA9WSSaVd8kujFFt3eIbShNqa4hLQNFvmVQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "workbox-core": "7.1.0"
+                "workbox-core": "7.3.0"
             }
         },
         "node_modules/workbox-recipes": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/workbox-recipes/-/workbox-recipes-7.1.0.tgz",
-            "integrity": "sha512-NRrk4ycFN9BHXJB6WrKiRX3W3w75YNrNrzSX9cEZgFB5ubeGoO8s/SDmOYVrFYp9HMw6sh1Pm3eAY/1gVS8YLg==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/workbox-recipes/-/workbox-recipes-7.3.0.tgz",
+            "integrity": "sha512-BJro/MpuW35I/zjZQBcoxsctgeB+kyb2JAP5EB3EYzePg8wDGoQuUdyYQS+CheTb+GhqJeWmVs3QxLI8EBP1sg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "workbox-cacheable-response": "7.1.0",
-                "workbox-core": "7.1.0",
-                "workbox-expiration": "7.1.0",
-                "workbox-precaching": "7.1.0",
-                "workbox-routing": "7.1.0",
-                "workbox-strategies": "7.1.0"
+                "workbox-cacheable-response": "7.3.0",
+                "workbox-core": "7.3.0",
+                "workbox-expiration": "7.3.0",
+                "workbox-precaching": "7.3.0",
+                "workbox-routing": "7.3.0",
+                "workbox-strategies": "7.3.0"
             }
         },
         "node_modules/workbox-routing": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-7.1.0.tgz",
-            "integrity": "sha512-oOYk+kLriUY2QyHkIilxUlVcFqwduLJB7oRZIENbqPGeBP/3TWHYNNdmGNhz1dvKuw7aqvJ7CQxn27/jprlTdg==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-7.3.0.tgz",
+            "integrity": "sha512-ZUlysUVn5ZUzMOmQN3bqu+gK98vNfgX/gSTZ127izJg/pMMy4LryAthnYtjuqcjkN4HEAx1mdgxNiKJMZQM76A==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "workbox-core": "7.1.0"
+                "workbox-core": "7.3.0"
             }
         },
         "node_modules/workbox-strategies": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-7.1.0.tgz",
-            "integrity": "sha512-/UracPiGhUNehGjRm/tLUQ+9PtWmCbRufWtV0tNrALuf+HZ4F7cmObSEK+E4/Bx1p8Syx2tM+pkIrvtyetdlew==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-7.3.0.tgz",
+            "integrity": "sha512-tmZydug+qzDFATwX7QiEL5Hdf7FrkhjaF9db1CbB39sDmEZJg3l9ayDvPxy8Y18C3Y66Nrr9kkN1f/RlkDgllg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "workbox-core": "7.1.0"
+                "workbox-core": "7.3.0"
             }
         },
         "node_modules/workbox-streams": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-7.1.0.tgz",
-            "integrity": "sha512-WyHAVxRXBMfysM8ORwiZnI98wvGWTVAq/lOyBjf00pXFvG0mNaVz4Ji+u+fKa/mf1i2SnTfikoYKto4ihHeS6w==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-7.3.0.tgz",
+            "integrity": "sha512-SZnXucyg8x2Y61VGtDjKPO5EgPUG5NDn/v86WYHX+9ZqvAsGOytP0Jxp1bl663YUuMoXSAtsGLL+byHzEuMRpw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "workbox-core": "7.1.0",
-                "workbox-routing": "7.1.0"
+                "workbox-core": "7.3.0",
+                "workbox-routing": "7.3.0"
             }
         },
         "node_modules/workbox-sw": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-7.1.0.tgz",
-            "integrity": "sha512-Hml/9+/njUXBglv3dtZ9WBKHI235AQJyLBV1G7EFmh4/mUdSQuXui80RtjDeVRrXnm/6QWgRUEHG3/YBVbxtsA==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-7.3.0.tgz",
+            "integrity": "sha512-aCUyoAZU9IZtH05mn0ACUpyHzPs0lMeJimAYkQkBsOWiqaJLgusfDCR+yllkPkFRxWpZKF8vSvgHYeG7LwhlmA==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/workbox-window": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-7.1.0.tgz",
-            "integrity": "sha512-ZHeROyqR+AS5UPzholQRDttLFqGMwP0Np8MKWAdyxsDETxq3qOAyXvqessc3GniohG6e0mAqSQyKOHmT8zPF7g==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-7.3.0.tgz",
+            "integrity": "sha512-qW8PDy16OV1UBaUNGlTVcepzrlzyzNW/ZJvFQQs2j2TzGsg6IKjcpZC1RSquqQnTOafl5pCj5bGfAHlCjOOjdA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@types/trusted-types": "^2.0.2",
-                "workbox-core": "7.1.0"
+                "workbox-core": "7.3.0"
             }
         },
         "node_modules/wrappy": {
@@ -10578,14 +9424,12 @@
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true,
-            "license": "ISC",
             "peer": true
         },
         "node_modules/xmlbuilder2": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-3.1.1.tgz",
             "integrity": "sha512-WCSfbfZnQDdLQLiMdGUQpMxxckeQ4oZNMNhLVkcekTu7xhD4tuUDyAPoY8CwXvBYE6LwBHd6QW2WZXlOWr1vCw==",
-            "license": "MIT",
             "dependencies": {
                 "@oozcitak/dom": "1.15.10",
                 "@oozcitak/infra": "1.0.8",
@@ -10600,7 +9444,6 @@
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "license": "MIT",
             "dependencies": {
                 "sprintf-js": "~1.0.2"
             }
@@ -10609,7 +9452,6 @@
             "version": "3.14.1",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
             "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-            "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -10623,7 +9465,6 @@
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true,
-            "license": "ISC",
             "peer": true
         },
         "node_modules/yocto-queue": {
@@ -10631,7 +9472,6 @@
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -10644,14 +9484,12 @@
             "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
             "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
         "packages/cli": {
-            "name": "@hylimo/cli",
             "version": "1.1.2",
             "license": "MIT",
             "dependencies": {
@@ -10664,8 +9502,15 @@
                 "cli": "lib/index.js"
             }
         },
+        "packages/cli/node_modules/commander": {
+            "version": "12.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+            "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "packages/core": {
-            "name": "@hylimo/core",
             "version": "1.1.2",
             "license": "MIT",
             "dependencies": {
@@ -10674,7 +9519,6 @@
             }
         },
         "packages/diagram": {
-            "name": "@hylimo/diagram",
             "version": "1.1.2",
             "license": "MIT",
             "dependencies": {
@@ -10692,7 +9536,6 @@
             }
         },
         "packages/diagram-common": {
-            "name": "@hylimo/diagram-common",
             "version": "1.1.2",
             "license": "MIT",
             "dependencies": {
@@ -10705,7 +9548,6 @@
             }
         },
         "packages/diagram-protocol": {
-            "name": "@hylimo/diagram-protocol",
             "version": "1.1.2",
             "license": "MIT",
             "dependencies": {
@@ -10715,7 +9557,6 @@
             }
         },
         "packages/diagram-render-pdf": {
-            "name": "@hylimo/diagram-render-pdf",
             "version": "1.1.2",
             "license": "MIT",
             "dependencies": {
@@ -10728,7 +9569,6 @@
             }
         },
         "packages/diagram-render-svg": {
-            "name": "@hylimo/diagram-render-svg",
             "version": "1.1.2",
             "license": "MIT",
             "dependencies": {
@@ -10737,7 +9577,6 @@
             }
         },
         "packages/diagram-ui": {
-            "name": "@hylimo/diagram-ui",
             "version": "1.1.2",
             "license": "EPL-2.0",
             "dependencies": {
@@ -10752,7 +9591,6 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.1.0.tgz",
             "integrity": "sha512-H0jc0q1vOzlEk0TqAKXKZxdl7kX3OFUzCnNVUnq5Pc3DGo0kpeaMuPqxQn235HibwBEb0/pm9dgKTjXy66fBkg==",
-            "license": "MIT",
             "dependencies": {
                 "yocto-queue": "^1.1.1"
             },
@@ -10767,7 +9605,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
             "integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
-            "license": "MIT",
             "engines": {
                 "node": ">=12.20"
             },
@@ -10776,12 +9613,10 @@
             }
         },
         "packages/fonts": {
-            "name": "@hylimo/fonts",
             "version": "1.1.2",
             "license": "MIT"
         },
         "packages/language-server": {
-            "name": "@hylimo/language-server",
             "version": "1.1.2",
             "license": "MIT",
             "dependencies": {
@@ -10796,7 +9631,6 @@
             }
         },
         "packages/wasm-libs": {
-            "name": "@hylimo/wasm-libs",
             "version": "1.1.2",
             "license": "MIT",
             "dependencies": {
@@ -10839,93 +9673,10 @@
                 "vue": "^3.5.13"
             }
         },
-        "website/node_modules/@vueuse/core": {
-            "version": "11.2.0",
-            "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-11.2.0.tgz",
-            "integrity": "sha512-JIUwRcOqOWzcdu1dGlfW04kaJhW3EXnnjJJfLTtddJanymTL7lF1C0+dVVZ/siLfc73mWn+cGP1PE1PKPruRSA==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/web-bluetooth": "^0.0.20",
-                "@vueuse/metadata": "11.2.0",
-                "@vueuse/shared": "11.2.0",
-                "vue-demi": ">=0.14.10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            }
-        },
-        "website/node_modules/@vueuse/core/node_modules/vue-demi": {
-            "version": "0.14.10",
-            "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
-            "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "bin": {
-                "vue-demi-fix": "bin/vue-demi-fix.js",
-                "vue-demi-switch": "bin/vue-demi-switch.js"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            },
-            "peerDependencies": {
-                "@vue/composition-api": "^1.0.0-rc.1",
-                "vue": "^3.0.0-0 || ^2.6.0"
-            },
-            "peerDependenciesMeta": {
-                "@vue/composition-api": {
-                    "optional": true
-                }
-            }
-        },
-        "website/node_modules/@vueuse/metadata": {
-            "version": "11.2.0",
-            "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-11.2.0.tgz",
-            "integrity": "sha512-L0ZmtRmNx+ZW95DmrgD6vn484gSpVeRbgpWevFKXwqqQxW9hnSi2Ppuh2BzMjnbv4aJRiIw8tQatXT9uOB23dQ==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            }
-        },
-        "website/node_modules/@vueuse/shared": {
-            "version": "11.2.0",
-            "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-11.2.0.tgz",
-            "integrity": "sha512-VxFjie0EanOudYSgMErxXfq6fo8vhr5ICI+BuE3I9FnX7ePllEsVrRQ7O6Q1TLgApeLuPKcHQxAXpP+KnlrJsg==",
-            "license": "MIT",
-            "dependencies": {
-                "vue-demi": ">=0.14.10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            }
-        },
-        "website/node_modules/@vueuse/shared/node_modules/vue-demi": {
-            "version": "0.14.10",
-            "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
-            "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "bin": {
-                "vue-demi-fix": "bin/vue-demi-fix.js",
-                "vue-demi-switch": "bin/vue-demi-switch.js"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            },
-            "peerDependencies": {
-                "@vue/composition-api": "^1.0.0-rc.1",
-                "vue": "^3.0.0-0 || ^2.6.0"
-            },
-            "peerDependenciesMeta": {
-                "@vue/composition-api": {
-                    "optional": true
-                }
-            }
+        "website/node_modules/pako": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+            "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,14 @@
             ],
             "devDependencies": {
                 "@types/wicg-file-system-access": "^2023.10.5",
-                "@typescript-eslint/eslint-plugin": "^8.10.0",
-                "@typescript-eslint/parser": "^8.10.0",
-                "eslint": "^9.13.0",
+                "@typescript-eslint/eslint-plugin": "^8.14.0",
+                "@typescript-eslint/parser": "^8.14.0",
+                "eslint": "^9.15.0",
                 "eslint-config-prettier": "^9.1.0",
                 "eslint-plugin-prettier": "^5.2.1",
                 "prettier": "^3.3.3",
                 "typescript": "^5.6.3",
-                "typescript-eslint": "^8.10.0"
+                "typescript-eslint": "^8.14.0"
             }
         },
         "node_modules/@algolia/autocomplete-core": {
@@ -3164,9 +3164,9 @@
             }
         },
         "node_modules/@eslint-community/regexpp": {
-            "version": "4.11.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.1.tgz",
-            "integrity": "sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==",
+            "version": "4.12.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+            "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3174,9 +3174,9 @@
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.18.0.tgz",
-            "integrity": "sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==",
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.0.tgz",
+            "integrity": "sha512-zdHg2FPIFNKPdcHWtiNT+jEFCHYVplAXRDlQDyqy0zGx/q2parwh7brGJSiTxRk/TSMkbM//zt/f5CHgyTyaSQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3213,9 +3213,9 @@
             }
         },
         "node_modules/@eslint/core": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.7.0.tgz",
-            "integrity": "sha512-xp5Jirz5DyPYlPiKat8jaq0EmYvDXKKpzTbxXMpT9eqlRJkRKIz9AGMdlvYjih+im+QlhWrpvVjl8IPC/lHlUw==",
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.0.tgz",
+            "integrity": "sha512-7ATR9F0e4W85D/0w7cU0SNj7qkAexMG+bAHEZOjo9akvGuhHE2m7umzWzfnpa0XAg5Kxc1BWmtPMV67jJ+9VUg==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -3223,9 +3223,9 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
-            "integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
+            "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3271,9 +3271,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.13.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.13.0.tgz",
-            "integrity": "sha512-IFLyoY4d72Z5y/6o/BazFBezupzI/taV8sGumxTAVw3lXG9A6md1Dc34T9s1FoD/an9pJH8RHbAxsaEbBed9lA==",
+            "version": "9.15.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.15.0.tgz",
+            "integrity": "sha512-tMTqrY+EzbXmKJR5ToI8lxu7jaN5EdmrBFJpQk5JmSlyLsx6o4t27r883K5xsLuCYCpfKBCGswMSWXsM+jB7lg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3291,9 +3291,9 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
-            "integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
+            "integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3304,9 +3304,9 @@
             }
         },
         "node_modules/@humanfs/core": {
-            "version": "0.19.0",
-            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.0.tgz",
-            "integrity": "sha512-2cbWIHbZVEweE853g8jymffCA+NCMiuqeECeBBLm8dg2oFdjuGJhgN4UAbI+6v0CKbbhvtXA4qV8YR5Ji86nmw==",
+            "version": "0.19.1",
+            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+            "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -3314,17 +3314,31 @@
             }
         },
         "node_modules/@humanfs/node": {
-            "version": "0.16.5",
-            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.5.tgz",
-            "integrity": "sha512-KSPA4umqSG4LHYRodq31VDwKAvaTF4xmVlzM8Aeh4PlU1JQ3IG0wiA8C25d3RQ9nJyM3mBHyI53K06VVL/oFFg==",
+            "version": "0.16.6",
+            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+            "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@humanfs/core": "^0.19.0",
+                "@humanfs/core": "^0.19.1",
                 "@humanwhocodes/retry": "^0.3.0"
             },
             "engines": {
                 "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+            "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
             }
         },
         "node_modules/@humanwhocodes/module-importer": {
@@ -3342,9 +3356,9 @@
             }
         },
         "node_modules/@humanwhocodes/retry": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-            "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
+            "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -3398,6 +3412,23 @@
         "node_modules/@hylimo/wasm-libs": {
             "resolved": "packages/wasm-libs",
             "link": true
+        },
+        "node_modules/@iconify-json/simple-icons": {
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.11.tgz",
+            "integrity": "sha512-AHCGDtBRqP+JzAbBzgO8uN/08CXxEmuaC6lQQZ3b5burKhRU12AJnJczwbUw2K5Mb/U85EpSUNhYMG3F28b8NA==",
+            "dev": true,
+            "license": "CC0-1.0",
+            "dependencies": {
+                "@iconify/types": "*"
+            }
+        },
+        "node_modules/@iconify/types": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+            "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.5",
@@ -3911,57 +3942,57 @@
             ]
         },
         "node_modules/@shikijs/core": {
-            "version": "1.22.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.22.0.tgz",
-            "integrity": "sha512-S8sMe4q71TJAW+qG93s5VaiihujRK6rqDFqBnxqvga/3LvqHEnxqBIOPkt//IdXVtHkQWKu4nOQNk0uBGicU7Q==",
+            "version": "1.23.1",
+            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.23.1.tgz",
+            "integrity": "sha512-NuOVgwcHgVC6jBVH5V7iblziw6iQbWWHrj5IlZI3Fqu2yx9awH7OIQkXIcsHsUmY19ckwSgUMgrqExEyP5A0TA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@shikijs/engine-javascript": "1.22.0",
-                "@shikijs/engine-oniguruma": "1.22.0",
-                "@shikijs/types": "1.22.0",
+                "@shikijs/engine-javascript": "1.23.1",
+                "@shikijs/engine-oniguruma": "1.23.1",
+                "@shikijs/types": "1.23.1",
                 "@shikijs/vscode-textmate": "^9.3.0",
                 "@types/hast": "^3.0.4",
                 "hast-util-to-html": "^9.0.3"
             }
         },
         "node_modules/@shikijs/engine-javascript": {
-            "version": "1.22.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.22.0.tgz",
-            "integrity": "sha512-AeEtF4Gcck2dwBqCFUKYfsCq0s+eEbCEbkUuFou53NZ0sTGnJnJ/05KHQFZxpii5HMXbocV9URYVowOP2wH5kw==",
+            "version": "1.23.1",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.23.1.tgz",
+            "integrity": "sha512-i/LdEwT5k3FVu07SiApRFwRcSJs5QM9+tod5vYCPig1Ywi8GR30zcujbxGQFJHwYD7A5BUqagi8o5KS+LEVgBg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "1.22.0",
+                "@shikijs/types": "1.23.1",
                 "@shikijs/vscode-textmate": "^9.3.0",
-                "oniguruma-to-js": "0.4.3"
+                "oniguruma-to-es": "0.4.1"
             }
         },
         "node_modules/@shikijs/engine-oniguruma": {
-            "version": "1.22.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.22.0.tgz",
-            "integrity": "sha512-5iBVjhu/DYs1HB0BKsRRFipRrD7rqjxlWTj4F2Pf+nQSPqc3kcyqFFeZXnBMzDf0HdqaFVvhDRAGiYNvyLP+Mw==",
+            "version": "1.23.1",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.23.1.tgz",
+            "integrity": "sha512-KQ+lgeJJ5m2ISbUZudLR1qHeH3MnSs2mjFg7bnencgs5jDVPeJ2NVDJ3N5ZHbcTsOIh0qIueyAJnwg7lg7kwXQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "1.22.0",
+                "@shikijs/types": "1.23.1",
                 "@shikijs/vscode-textmate": "^9.3.0"
             }
         },
         "node_modules/@shikijs/transformers": {
-            "version": "1.22.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.22.0.tgz",
-            "integrity": "sha512-k7iMOYuGQA62KwAuJOQBgH2IQb5vP8uiB3lMvAMGUgAMMurePOx3Z7oNqJdcpxqZP6I9cc7nc4DNqSKduCxmdg==",
+            "version": "1.23.1",
+            "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.23.1.tgz",
+            "integrity": "sha512-yQ2Cn0M9i46p30KwbyIzLvKDk+dQNU+lj88RGO0XEj54Hn4Cof1bZoDb9xBRWxFE4R8nmK63w7oHnJwvOtt0NQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "shiki": "1.22.0"
+                "shiki": "1.23.1"
             }
         },
         "node_modules/@shikijs/types": {
-            "version": "1.22.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.22.0.tgz",
-            "integrity": "sha512-Fw/Nr7FGFhlQqHfxzZY8Cwtwk5E9nKDUgeLjZgt3UuhcM3yJR9xj3ZGNravZZok8XmEZMiYkSMTPlPkULB8nww==",
+            "version": "1.23.1",
+            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.23.1.tgz",
+            "integrity": "sha512-98A5hGyEhzzAgQh2dAeHKrWW4HfCMeoFER2z16p5eJ+vmPeF6lZ/elEne6/UCU551F/WqkopqRsr1l2Yu6+A0g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4163,17 +4194,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.10.0.tgz",
-            "integrity": "sha512-phuB3hoP7FFKbRXxjl+DRlQDuJqhpOnm5MmtROXyWi3uS/Xg2ZXqiQfcG2BJHiN4QKyzdOJi3NEn/qTnjUlkmQ==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.14.0.tgz",
+            "integrity": "sha512-tqp8H7UWFaZj0yNO6bycd5YjMwxa6wIHOLZvWPkidwbgLCsBMetQoGj7DPuAlWa2yGO3H48xmPwjhsSPPCGU5w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.10.0",
-                "@typescript-eslint/type-utils": "8.10.0",
-                "@typescript-eslint/utils": "8.10.0",
-                "@typescript-eslint/visitor-keys": "8.10.0",
+                "@typescript-eslint/scope-manager": "8.14.0",
+                "@typescript-eslint/type-utils": "8.14.0",
+                "@typescript-eslint/utils": "8.14.0",
+                "@typescript-eslint/visitor-keys": "8.14.0",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.3.1",
                 "natural-compare": "^1.4.0",
@@ -4197,16 +4228,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.10.0.tgz",
-            "integrity": "sha512-E24l90SxuJhytWJ0pTQydFT46Nk0Z+bsLKo/L8rtQSL93rQ6byd1V/QbDpHUTdLPOMsBCcYXZweADNCfOCmOAg==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.14.0.tgz",
+            "integrity": "sha512-2p82Yn9juUJq0XynBXtFCyrBDb6/dJombnz6vbo6mgQEtWHfvHbQuEa9kAOVIt1c9YFwi7H6WxtPj1kg+80+RA==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.10.0",
-                "@typescript-eslint/types": "8.10.0",
-                "@typescript-eslint/typescript-estree": "8.10.0",
-                "@typescript-eslint/visitor-keys": "8.10.0",
+                "@typescript-eslint/scope-manager": "8.14.0",
+                "@typescript-eslint/types": "8.14.0",
+                "@typescript-eslint/typescript-estree": "8.14.0",
+                "@typescript-eslint/visitor-keys": "8.14.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -4226,14 +4257,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.10.0.tgz",
-            "integrity": "sha512-AgCaEjhfql9MDKjMUxWvH7HjLeBqMCBfIaBbzzIcBbQPZE7CPh1m6FF+L75NUMJFMLYhCywJXIDEMa3//1A0dw==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.14.0.tgz",
+            "integrity": "sha512-aBbBrnW9ARIDn92Zbo7rguLnqQ/pOrUguVpbUwzOhkFg2npFDwTgPGqFqE0H5feXcOoJOfX3SxlJaKEVtq54dw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.10.0",
-                "@typescript-eslint/visitor-keys": "8.10.0"
+                "@typescript-eslint/types": "8.14.0",
+                "@typescript-eslint/visitor-keys": "8.14.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4244,14 +4275,14 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.10.0.tgz",
-            "integrity": "sha512-PCpUOpyQSpxBn230yIcK+LeCQaXuxrgCm2Zk1S+PTIRJsEfU6nJ0TtwyH8pIwPK/vJoA+7TZtzyAJSGBz+s/dg==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.14.0.tgz",
+            "integrity": "sha512-Xcz9qOtZuGusVOH5Uk07NGs39wrKkf3AxlkK79RBK6aJC1l03CobXjJbwBPSidetAOV+5rEVuiT1VSBUOAsanQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.10.0",
-                "@typescript-eslint/utils": "8.10.0",
+                "@typescript-eslint/typescript-estree": "8.14.0",
+                "@typescript-eslint/utils": "8.14.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.3.0"
             },
@@ -4269,9 +4300,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.10.0.tgz",
-            "integrity": "sha512-k/E48uzsfJCRRbGLapdZgrX52csmWJ2rcowwPvOZ8lwPUv3xW6CcFeJAXgx4uJm+Ge4+a4tFOkdYvSpxhRhg1w==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.14.0.tgz",
+            "integrity": "sha512-yjeB9fnO/opvLJFAsPNYlKPnEM8+z4og09Pk504dkqonT02AyL5Z9SSqlE0XqezS93v6CXn49VHvB2G7XSsl0g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4283,14 +4314,14 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.10.0.tgz",
-            "integrity": "sha512-3OE0nlcOHaMvQ8Xu5gAfME3/tWVDpb/HxtpUZ1WeOAksZ/h/gwrBzCklaGzwZT97/lBbbxJ16dMA98JMEngW4w==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.14.0.tgz",
+            "integrity": "sha512-OPXPLYKGZi9XS/49rdaCbR5j/S14HazviBlUQFvSKz3npr3NikF+mrgK7CFVur6XEt95DZp/cmke9d5i3vtVnQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "@typescript-eslint/types": "8.10.0",
-                "@typescript-eslint/visitor-keys": "8.10.0",
+                "@typescript-eslint/types": "8.14.0",
+                "@typescript-eslint/visitor-keys": "8.14.0",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -4312,16 +4343,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.10.0.tgz",
-            "integrity": "sha512-Oq4uZ7JFr9d1ZunE/QKy5egcDRXT/FrS2z/nlxzPua2VHFtmMvFNDvpq1m/hq0ra+T52aUezfcjGRIB7vNJF9w==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.14.0.tgz",
+            "integrity": "sha512-OGqj6uB8THhrHj0Fk27DcHPojW7zKwKkPmHXHvQ58pLYp4hy8CSUdTKykKeh+5vFqTTVmjz0zCOOPKRovdsgHA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "8.10.0",
-                "@typescript-eslint/types": "8.10.0",
-                "@typescript-eslint/typescript-estree": "8.10.0"
+                "@typescript-eslint/scope-manager": "8.14.0",
+                "@typescript-eslint/types": "8.14.0",
+                "@typescript-eslint/typescript-estree": "8.14.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4335,13 +4366,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.10.0.tgz",
-            "integrity": "sha512-k8nekgqwr7FadWk548Lfph6V3r9OVqjzAIVskE7orMZR23cGJjAOVazsZSJW+ElyjfTM4wx/1g88Mi70DDtG9A==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.14.0.tgz",
+            "integrity": "sha512-vG0XZo8AdTH9OE6VFRwAZldNc7qtJ/6NLGWak+BtENuEUXGZgFpihILPiBvKXvJ2nFu27XNGC6rKiwuaoMbYzQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.10.0",
+                "@typescript-eslint/types": "8.14.0",
                 "eslint-visitor-keys": "^3.4.3"
             },
             "engines": {
@@ -4399,74 +4430,74 @@
             "license": "MIT"
         },
         "node_modules/@vue/compiler-core": {
-            "version": "3.5.12",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.12.tgz",
-            "integrity": "sha512-ISyBTRMmMYagUxhcpyEH0hpXRd/KqDU4ymofPgl2XAkY9ZhQ+h0ovEZJIiPop13UmR/54oA2cgMDjgroRelaEw==",
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
+            "integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.25.3",
-                "@vue/shared": "3.5.12",
+                "@vue/shared": "3.5.13",
                 "entities": "^4.5.0",
                 "estree-walker": "^2.0.2",
                 "source-map-js": "^1.2.0"
             }
         },
         "node_modules/@vue/compiler-dom": {
-            "version": "3.5.12",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.12.tgz",
-            "integrity": "sha512-9G6PbJ03uwxLHKQ3P42cMTi85lDRvGLB2rSGOiQqtXELat6uI4n8cNz9yjfVHRPIu+MsK6TE418Giruvgptckg==",
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz",
+            "integrity": "sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-core": "3.5.12",
-                "@vue/shared": "3.5.12"
+                "@vue/compiler-core": "3.5.13",
+                "@vue/shared": "3.5.13"
             }
         },
         "node_modules/@vue/compiler-sfc": {
-            "version": "3.5.12",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.12.tgz",
-            "integrity": "sha512-2k973OGo2JuAa5+ZlekuQJtitI5CgLMOwgl94BzMCsKZCX/xiqzJYzapl4opFogKHqwJk34vfsaKpfEhd1k5nw==",
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.13.tgz",
+            "integrity": "sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==",
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.25.3",
-                "@vue/compiler-core": "3.5.12",
-                "@vue/compiler-dom": "3.5.12",
-                "@vue/compiler-ssr": "3.5.12",
-                "@vue/shared": "3.5.12",
+                "@vue/compiler-core": "3.5.13",
+                "@vue/compiler-dom": "3.5.13",
+                "@vue/compiler-ssr": "3.5.13",
+                "@vue/shared": "3.5.13",
                 "estree-walker": "^2.0.2",
                 "magic-string": "^0.30.11",
-                "postcss": "^8.4.47",
+                "postcss": "^8.4.48",
                 "source-map-js": "^1.2.0"
             }
         },
         "node_modules/@vue/compiler-ssr": {
-            "version": "3.5.12",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.12.tgz",
-            "integrity": "sha512-eLwc7v6bfGBSM7wZOGPmRavSWzNFF6+PdRhE+VFJhNCgHiF8AM7ccoqcv5kBXA2eWUfigD7byekvf/JsOfKvPA==",
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.13.tgz",
+            "integrity": "sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-dom": "3.5.12",
-                "@vue/shared": "3.5.12"
+                "@vue/compiler-dom": "3.5.13",
+                "@vue/shared": "3.5.13"
             }
         },
         "node_modules/@vue/devtools-api": {
-            "version": "7.4.6",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.4.6.tgz",
-            "integrity": "sha512-XipBV5k0/IfTr0sNBDTg7OBUCp51cYMMXyPxLXJZ4K/wmUeMqt8cVdr2ZZGOFq+si/jTyCYnNxeKoyev5DOUUA==",
+            "version": "7.6.4",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.6.4.tgz",
+            "integrity": "sha512-5AaJ5ELBIuevmFMZYYLuOO9HUuY/6OlkOELHE7oeDhy4XD/hSODIzktlsvBOsn+bto3aD0psj36LGzwVu5Ip8w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vue/devtools-kit": "^7.4.6"
+                "@vue/devtools-kit": "^7.6.4"
             }
         },
         "node_modules/@vue/devtools-kit": {
-            "version": "7.4.6",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.4.6.tgz",
-            "integrity": "sha512-NbYBwPWgEic1AOd9bWExz9weBzFdjiIfov0yRn4DrRfR+EQJCI9dn4I0XS7IxYGdkmUJi8mFW42LLk18WsGqew==",
+            "version": "7.6.4",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.6.4.tgz",
+            "integrity": "sha512-Zs86qIXXM9icU0PiGY09PQCle4TI750IPLmAJzW5Kf9n9t5HzSYf6Rz6fyzSwmfMPiR51SUKJh9sXVZu78h2QA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vue/devtools-shared": "^7.4.6",
-                "birpc": "^0.2.17",
+                "@vue/devtools-shared": "^7.6.4",
+                "birpc": "^0.2.19",
                 "hookable": "^5.5.3",
                 "mitt": "^3.0.1",
                 "perfect-debounce": "^1.0.0",
@@ -4475,9 +4506,9 @@
             }
         },
         "node_modules/@vue/devtools-shared": {
-            "version": "7.4.6",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.4.6.tgz",
-            "integrity": "sha512-rPeSBzElnHYMB05Cc056BQiJpgocQjY8XVulgni+O9a9Gr9tNXgPteSzFFD+fT/iWMxNuUgGKs9CuW5DZewfIg==",
+            "version": "7.6.4",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.6.4.tgz",
+            "integrity": "sha512-nD6CUvBEel+y7zpyorjiUocy0nh77DThZJ0k1GRnJeOmY3ATq2fWijEp7wk37gb023Cb0R396uYh5qMSBQ5WFg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4485,59 +4516,60 @@
             }
         },
         "node_modules/@vue/reactivity": {
-            "version": "3.5.12",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.12.tgz",
-            "integrity": "sha512-UzaN3Da7xnJXdz4Okb/BGbAaomRHc3RdoWqTzlvd9+WBR5m3J39J1fGcHes7U3za0ruYn/iYy/a1euhMEHvTAg==",
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.13.tgz",
+            "integrity": "sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==",
             "license": "MIT",
             "dependencies": {
-                "@vue/shared": "3.5.12"
+                "@vue/shared": "3.5.13"
             }
         },
         "node_modules/@vue/runtime-core": {
-            "version": "3.5.12",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.12.tgz",
-            "integrity": "sha512-hrMUYV6tpocr3TL3Ad8DqxOdpDe4zuQY4HPY3X/VRh+L2myQO8MFXPAMarIOSGNu0bFAjh1yBkMPXZBqCk62Uw==",
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.13.tgz",
+            "integrity": "sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==",
             "license": "MIT",
             "dependencies": {
-                "@vue/reactivity": "3.5.12",
-                "@vue/shared": "3.5.12"
+                "@vue/reactivity": "3.5.13",
+                "@vue/shared": "3.5.13"
             }
         },
         "node_modules/@vue/runtime-dom": {
-            "version": "3.5.12",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.12.tgz",
-            "integrity": "sha512-q8VFxR9A2MRfBr6/55Q3umyoN7ya836FzRXajPB6/Vvuv0zOPL+qltd9rIMzG/DbRLAIlREmnLsplEF/kotXKA==",
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.13.tgz",
+            "integrity": "sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==",
             "license": "MIT",
             "dependencies": {
-                "@vue/reactivity": "3.5.12",
-                "@vue/runtime-core": "3.5.12",
-                "@vue/shared": "3.5.12",
+                "@vue/reactivity": "3.5.13",
+                "@vue/runtime-core": "3.5.13",
+                "@vue/shared": "3.5.13",
                 "csstype": "^3.1.3"
             }
         },
         "node_modules/@vue/server-renderer": {
-            "version": "3.5.12",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.12.tgz",
-            "integrity": "sha512-I3QoeDDeEPZm8yR28JtY+rk880Oqmj43hreIBVTicisFTx/Dl7JpG72g/X7YF8hnQD3IFhkky5i2bPonwrTVPg==",
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.13.tgz",
+            "integrity": "sha512-wAi4IRJV/2SAW3htkTlB+dHeRmpTiVIK1OGLWV1yeStVSebSQQOwGwIq0D3ZIoBj2C2qpgz5+vX9iEBkTdk5YA==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-ssr": "3.5.12",
-                "@vue/shared": "3.5.12"
+                "@vue/compiler-ssr": "3.5.13",
+                "@vue/shared": "3.5.13"
             },
             "peerDependencies": {
-                "vue": "3.5.12"
+                "vue": "3.5.13"
             }
         },
         "node_modules/@vue/shared": {
-            "version": "3.5.12",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.12.tgz",
-            "integrity": "sha512-L2RPSAwUFbgZH20etwrXyVyCBu9OxRSi8T/38QsvnkJyvq2LufW2lDCOzm7t/U9C1mkhJGWYfCuFBCmIuNivrg==",
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
+            "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
             "license": "MIT"
         },
         "node_modules/@vueuse/core": {
             "version": "11.1.0",
             "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-11.1.0.tgz",
             "integrity": "sha512-P6dk79QYA6sKQnghrUz/1tHi0n9mrb/iO1WTMk/ElLmTyNqgDeSZ3wcDf6fRBGzRJbeG1dxzEOvLENMjr+E3fg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/web-bluetooth": "^0.0.20",
@@ -4553,6 +4585,7 @@
             "version": "0.14.10",
             "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
             "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
@@ -4673,6 +4706,7 @@
             "version": "11.1.0",
             "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-11.1.0.tgz",
             "integrity": "sha512-l9Q502TBTaPYGanl1G+hPgd3QX5s4CGnpXriVBR5fEZ/goI6fvDaVmIl3Td8oKFurOxTmbXvBPSsgrd6eu6HYg==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
@@ -4682,6 +4716,7 @@
             "version": "11.1.0",
             "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-11.1.0.tgz",
             "integrity": "sha512-YUtIpY122q7osj+zsNMFAfMTubGz0sn5QzE5gPzAIiCmtt2ha3uQUY1+JPyL4gRCTsLPX82Y9brNbo/aqlA91w==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "vue-demi": ">=0.14.10"
@@ -4694,6 +4729,7 @@
             "version": "0.14.10",
             "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
             "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
@@ -4717,9 +4753,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.12.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-            "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+            "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -5042,9 +5078,9 @@
             }
         },
         "node_modules/birpc": {
-            "version": "0.2.17",
-            "resolved": "https://registry.npmjs.org/birpc/-/birpc-0.2.17.tgz",
-            "integrity": "sha512-+hkTxhot+dWsLpp3gia5AkVHIsKlZybNT5gIYiDlNzJrmYPcTM9k5/w2uaj3IPpd7LlEYpmCj4Jj1nC41VhDFg==",
+            "version": "0.2.19",
+            "resolved": "https://registry.npmjs.org/birpc/-/birpc-0.2.19.tgz",
+            "integrity": "sha512-5WeXXAvTmitV1RqJFppT5QtUiz2p1mRSYU000Jkft5ZUCLJIk4uQriYNO50HknxKwM6jd8utNc66K1qGIwwWBQ==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -5385,9 +5421,9 @@
             }
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
+            "integrity": "sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5661,6 +5697,13 @@
             "license": "ISC",
             "peer": true
         },
+        "node_modules/emoji-regex-xs": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+            "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/entities": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -5889,32 +5932,32 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.13.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.13.0.tgz",
-            "integrity": "sha512-EYZK6SX6zjFHST/HRytOdA/zE72Cq/bfw45LSyuwrdvcclb/gqV8RRQxywOBEWO2+WDpva6UZa4CcDeJKzUCFA==",
+            "version": "9.15.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.15.0.tgz",
+            "integrity": "sha512-7CrWySmIibCgT1Os28lUU6upBshZ+GxybLOrmRzi08kS8MBuO8QA7pXEgYgY5W8vK3e74xv0lpjo9DbaGU9Rkw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
-                "@eslint-community/regexpp": "^4.11.0",
-                "@eslint/config-array": "^0.18.0",
-                "@eslint/core": "^0.7.0",
-                "@eslint/eslintrc": "^3.1.0",
-                "@eslint/js": "9.13.0",
-                "@eslint/plugin-kit": "^0.2.0",
-                "@humanfs/node": "^0.16.5",
+                "@eslint-community/regexpp": "^4.12.1",
+                "@eslint/config-array": "^0.19.0",
+                "@eslint/core": "^0.9.0",
+                "@eslint/eslintrc": "^3.2.0",
+                "@eslint/js": "9.15.0",
+                "@eslint/plugin-kit": "^0.2.3",
+                "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
-                "@humanwhocodes/retry": "^0.3.1",
+                "@humanwhocodes/retry": "^0.4.1",
                 "@types/estree": "^1.0.6",
                 "@types/json-schema": "^7.0.15",
                 "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
-                "cross-spawn": "^7.0.2",
+                "cross-spawn": "^7.0.5",
                 "debug": "^4.3.2",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^8.1.0",
-                "eslint-visitor-keys": "^4.1.0",
-                "espree": "^10.2.0",
+                "eslint-scope": "^8.2.0",
+                "eslint-visitor-keys": "^4.2.0",
+                "espree": "^10.3.0",
                 "esquery": "^1.5.0",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
@@ -5928,8 +5971,7 @@
                 "lodash.merge": "^4.6.2",
                 "minimatch": "^3.1.2",
                 "natural-compare": "^1.4.0",
-                "optionator": "^0.9.3",
-                "text-table": "^0.2.0"
+                "optionator": "^0.9.3"
             },
             "bin": {
                 "eslint": "bin/eslint.js"
@@ -5994,9 +6036,9 @@
             }
         },
         "node_modules/eslint-scope": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.1.0.tgz",
-            "integrity": "sha512-14dSvlhaVhKKsa9Fx1l8A17s7ah7Ef7wCakJ10LYk6+GYmP9yDti2oq2SEwcyndt6knfcZyhyxwY3i9yL78EQw==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
+            "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -6035,9 +6077,9 @@
             }
         },
         "node_modules/eslint/node_modules/eslint-visitor-keys": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.1.0.tgz",
-            "integrity": "sha512-Q7lok0mqMUSf5a/AdAZkA5a/gHcO6snwQClVNNvFKCAVlxXucdU8pKydU5ZVZjBx5xr37vGbFFWtLQYreLzrZg==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+            "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -6061,15 +6103,15 @@
             }
         },
         "node_modules/espree": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-10.2.0.tgz",
-            "integrity": "sha512-upbkBJbckcCNBDBDXEbuhjbP68n+scUd3k/U2EkyM9nw+I/jPiL4cLF/Al06CF96wRltFda16sxDFrxsI1v0/g==",
+            "version": "10.3.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+            "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "acorn": "^8.12.0",
+                "acorn": "^8.14.0",
                 "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^4.1.0"
+                "eslint-visitor-keys": "^4.2.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6079,9 +6121,9 @@
             }
         },
         "node_modules/espree/node_modules/eslint-visitor-keys": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.1.0.tgz",
-            "integrity": "sha512-Q7lok0mqMUSf5a/AdAZkA5a/gHcO6snwQClVNNvFKCAVlxXucdU8pKydU5ZVZjBx5xr37vGbFFWtLQYreLzrZg==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+            "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -6658,9 +6700,9 @@
             "license": "MIT"
         },
         "node_modules/harfbuzzjs": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/harfbuzzjs/-/harfbuzzjs-0.4.2.tgz",
-            "integrity": "sha512-ezF/y31J5qlO9zZ9I0YxlR5MFizMixRR7AIRwpmkbCURyJV1OwV8NSTFOf+YQgDVRHNiV9UtPaj4gX+F3op9OA==",
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/harfbuzzjs/-/harfbuzzjs-0.4.3.tgz",
+            "integrity": "sha512-g7yRM1C7/le3PN9GPNufA3T1PEugOVOrG1WbDZKR0Olx0rft+1VKr0dx9nDcdBOT9vDXtXCH2/5fjc16OvRg5Q==",
             "license": "MIT"
         },
         "node_modules/has-bigints": {
@@ -7648,9 +7690,9 @@
             }
         },
         "node_modules/micromark-util-character": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
-            "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+            "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
             "dev": true,
             "funding": [
                 {
@@ -7669,9 +7711,9 @@
             }
         },
         "node_modules/micromark-util-encode": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
-            "integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+            "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
             "dev": true,
             "funding": [
                 {
@@ -7686,9 +7728,9 @@
             "license": "MIT"
         },
         "node_modules/micromark-util-sanitize-uri": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
-            "integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+            "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
             "dev": true,
             "funding": [
                 {
@@ -7708,9 +7750,9 @@
             }
         },
         "node_modules/micromark-util-symbol": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
-            "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+            "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
             "dev": true,
             "funding": [
                 {
@@ -7725,9 +7767,9 @@
             "license": "MIT"
         },
         "node_modules/micromark-util-types": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
-            "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.1.tgz",
+            "integrity": "sha512-534m2WhVTddrcKVepwmVEVnUAmtrx9bfIjNoQHRqfnvdaHQiFytEhJoTgpWJvDEXCO5gLTQh3wYC1PgOJA4NSQ==",
             "dev": true,
             "funding": [
                 {
@@ -8008,17 +8050,16 @@
                 "wrappy": "1"
             }
         },
-        "node_modules/oniguruma-to-js": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/oniguruma-to-js/-/oniguruma-to-js-0.4.3.tgz",
-            "integrity": "sha512-X0jWUcAlxORhOqqBREgPMgnshB7ZGYszBNspP+tS9hPD3l13CdaXcHbgImoHUHlrvGx/7AvFEkTRhAGYh+jzjQ==",
+        "node_modules/oniguruma-to-es": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-0.4.1.tgz",
+            "integrity": "sha512-rNcEohFz095QKGRovP/yqPIKc+nP+Sjs4YTHMv33nMePGKrq/r2eu9Yh4646M5XluGJsUnmwoXuiXE69KDs+fQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "regex": "^4.3.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
+                "emoji-regex-xs": "^1.0.0",
+                "regex": "^5.0.0",
+                "regex-recursion": "^4.2.1"
             }
         },
         "node_modules/optionator": {
@@ -8129,9 +8170,9 @@
             "license": "MIT"
         },
         "node_modules/pdfkit": {
-            "version": "0.15.0",
-            "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.15.0.tgz",
-            "integrity": "sha512-Z0dx0sEPKLW2kbThS1SWZ0iSHlRPoFMpP+oSjNrtwRjsfGivwE+r6emyEFwQG/fx1Ri0AGUHmDcGOSMMlLLnSg==",
+            "version": "0.15.1",
+            "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.15.1.tgz",
+            "integrity": "sha512-sleaMQXbQ/Dk+38HlxdiMT6Lmw5+HoNc4vkJR1Tb9XGALuB1xrfdWYbDFta70F3jCrVkhA2DiQ52D7jbysGZrw==",
             "license": "MIT",
             "dependencies": {
                 "crypto-js": "^4.2.0",
@@ -8181,9 +8222,9 @@
             "license": "MIT"
         },
         "node_modules/picocolors": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-            "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
             "license": "ISC"
         },
         "node_modules/picomatch": {
@@ -8214,9 +8255,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.47",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
-            "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
+            "version": "8.4.49",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+            "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -8234,7 +8275,7 @@
             "license": "MIT",
             "dependencies": {
                 "nanoid": "^3.3.7",
-                "picocolors": "^1.1.0",
+                "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
             "engines": {
@@ -8414,9 +8455,26 @@
             }
         },
         "node_modules/regex": {
-            "version": "4.3.3",
-            "resolved": "https://registry.npmjs.org/regex/-/regex-4.3.3.tgz",
-            "integrity": "sha512-r/AadFO7owAq1QJVeZ/nq9jNS1vyZt+6t1p/E59B56Rn2GCya+gr1KSyOzNL/er+r+B7phv5jG2xU2Nz1YkmJg==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/regex/-/regex-5.0.1.tgz",
+            "integrity": "sha512-gIS00E8eHNWONxofNKOhtlkwBQj/K39ZJamnvMEFH3pNKc06Zz2jtFXF/4ldAaJTzQNhMJU7b5+C7tTq2ukV7Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/regex-recursion": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-4.2.1.tgz",
+            "integrity": "sha512-QHNZyZAeKdndD1G3bKAbBEKOSSK4KOHQrAJ01N1LJeb0SoH4DJIeFhp0uUpETgONifS4+P3sOgoA1dhzgrQvhA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "regex-utilities": "^2.3.0"
+            }
+        },
+        "node_modules/regex-utilities": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+            "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
             "dev": true,
             "license": "MIT"
         },
@@ -8750,16 +8808,16 @@
             }
         },
         "node_modules/shiki": {
-            "version": "1.22.0",
-            "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.22.0.tgz",
-            "integrity": "sha512-/t5LlhNs+UOKQCYBtl5ZsH/Vclz73GIqT2yQsCBygr8L/ppTdmpL4w3kPLoZJbMKVWtoG77Ue1feOjZfDxvMkw==",
+            "version": "1.23.1",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.23.1.tgz",
+            "integrity": "sha512-8kxV9TH4pXgdKGxNOkrSMydn1Xf6It8lsle0fiqxf7a1149K1WGtdOu3Zb91T5r1JpvRPxqxU3C2XdZZXQnrig==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@shikijs/core": "1.22.0",
-                "@shikijs/engine-javascript": "1.22.0",
-                "@shikijs/engine-oniguruma": "1.22.0",
-                "@shikijs/types": "1.22.0",
+                "@shikijs/core": "1.23.1",
+                "@shikijs/engine-javascript": "1.23.1",
+                "@shikijs/engine-oniguruma": "1.23.1",
+                "@shikijs/types": "1.23.1",
                 "@shikijs/vscode-textmate": "^9.3.0",
                 "@types/hast": "^3.0.4"
             }
@@ -9191,13 +9249,6 @@
             "license": "MIT",
             "peer": true
         },
-        "node_modules/text-table": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/tiny-inflate": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
@@ -9450,15 +9501,15 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.10.0.tgz",
-            "integrity": "sha512-YIu230PeN7z9zpu/EtqCIuRVHPs4iSlqW6TEvjbyDAE3MZsSl2RXBo+5ag+lbABCG8sFM1WVKEXhlQ8Ml8A3Fw==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.14.0.tgz",
+            "integrity": "sha512-K8fBJHxVL3kxMmwByvz8hNdBJ8a0YqKzKDX6jRlrjMuNXyd5T2V02HIq37+OiWXvUUOXgOOGiSSOh26Mh8pC3w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.10.0",
-                "@typescript-eslint/parser": "8.10.0",
-                "@typescript-eslint/utils": "8.10.0"
+                "@typescript-eslint/eslint-plugin": "8.14.0",
+                "@typescript-eslint/parser": "8.14.0",
+                "@typescript-eslint/utils": "8.14.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -9724,16 +9775,16 @@
             }
         },
         "node_modules/uuid": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-            "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+            "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
             "funding": [
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"
             ],
             "license": "MIT",
             "bin": {
-                "uuid": "dist/bin/uuid"
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/vfile": {
@@ -9767,9 +9818,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "5.4.8",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.8.tgz",
-            "integrity": "sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==",
+            "version": "5.4.11",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
+            "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9859,28 +9910,29 @@
             }
         },
         "node_modules/vitepress": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.4.1.tgz",
-            "integrity": "sha512-C2rQ7PMlDVqgsaHOa0uJtgGGWaGv74QMaGL62lxKbtFkYtosJB5HAfZ8+pEbfzzvLemYaYwaiQdFLBlexK2sFw==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.5.0.tgz",
+            "integrity": "sha512-q4Q/G2zjvynvizdB3/bupdYkCJe2umSAMv9Ju4d92E6/NXJ59z70xB0q5p/4lpRyAwflDsbwy1mLV9Q5+nlB+g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@docsearch/css": "^3.6.2",
                 "@docsearch/js": "^3.6.2",
-                "@shikijs/core": "^1.22.0",
-                "@shikijs/transformers": "^1.22.0",
-                "@shikijs/types": "^1.22.0",
+                "@iconify-json/simple-icons": "^1.2.10",
+                "@shikijs/core": "^1.22.2",
+                "@shikijs/transformers": "^1.22.2",
+                "@shikijs/types": "^1.22.2",
                 "@types/markdown-it": "^14.1.2",
                 "@vitejs/plugin-vue": "^5.1.4",
-                "@vue/devtools-api": "^7.4.6",
+                "@vue/devtools-api": "^7.5.4",
                 "@vue/shared": "^3.5.12",
                 "@vueuse/core": "^11.1.0",
                 "@vueuse/integrations": "^11.1.0",
                 "focus-trap": "^7.6.0",
                 "mark.js": "8.11.1",
                 "minisearch": "^7.1.0",
-                "shiki": "^1.22.0",
-                "vite": "^5.4.8",
+                "shiki": "^1.22.2",
+                "vite": "^5.4.10",
                 "vue": "^3.5.12"
             },
             "bin": {
@@ -10021,16 +10073,16 @@
             }
         },
         "node_modules/vue": {
-            "version": "3.5.12",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.12.tgz",
-            "integrity": "sha512-CLVZtXtn2ItBIi/zHZ0Sg1Xkb7+PU32bJJ8Bmy7ts3jxXTcbfsEfBivFYYWz1Hur+lalqGAh65Coin0r+HRUfg==",
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.13.tgz",
+            "integrity": "sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-dom": "3.5.12",
-                "@vue/compiler-sfc": "3.5.12",
-                "@vue/runtime-dom": "3.5.12",
-                "@vue/server-renderer": "3.5.12",
-                "@vue/shared": "3.5.12"
+                "@vue/compiler-dom": "3.5.13",
+                "@vue/compiler-sfc": "3.5.13",
+                "@vue/runtime-dom": "3.5.13",
+                "@vue/server-renderer": "3.5.13",
+                "@vue/shared": "3.5.13"
             },
             "peerDependencies": {
                 "typescript": "*"
@@ -10678,7 +10730,7 @@
             "dependencies": {
                 "@hylimo/diagram": "^1.1.2",
                 "@hylimo/diagram-render-svg": "^1.1.2",
-                "pdfkit": "^0.15.0"
+                "pdfkit": "^0.15.1"
             },
             "devDependencies": {
                 "@types/pdfkit": "^0.13.5"
@@ -10757,7 +10809,7 @@
             "version": "1.1.2",
             "license": "MIT",
             "dependencies": {
-                "harfbuzzjs": "^0.4.2"
+                "harfbuzzjs": "^0.4.3"
             },
             "devDependencies": {
                 "@rollup/plugin-node-resolve": "^15.3.0",
@@ -10773,7 +10825,7 @@
                 "@hylimo/diagram-render-svg": "^1.1.2",
                 "@hylimo/diagram-ui": "^1.1.2",
                 "@hylimo/language-server": "^1.1.2",
-                "@vueuse/core": "^11.1.0",
+                "@vueuse/core": "^11.2.0",
                 "file-saver": "^2.0.5",
                 "js-base64": "^3.7.7",
                 "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@~8.0.4",
@@ -10783,7 +10835,7 @@
                 "reflect-metadata": "^0.2.2",
                 "splitpanes": "^3.1.5",
                 "sprotty": "^1.3.0",
-                "uuid": "^10.0.0",
+                "uuid": "^11.0.3",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-protocol": "^3.17.5"
             },
@@ -10792,8 +10844,96 @@
                 "@types/pako": "^2.0.3",
                 "@types/uuid": "^10.0.0",
                 "@vite-pwa/vitepress": "^0.5.3",
-                "vitepress": "^1.4.1",
-                "vue": "^3.5.12"
+                "vitepress": "^1.5.0",
+                "vue": "^3.5.13"
+            }
+        },
+        "website/node_modules/@vueuse/core": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-11.2.0.tgz",
+            "integrity": "sha512-JIUwRcOqOWzcdu1dGlfW04kaJhW3EXnnjJJfLTtddJanymTL7lF1C0+dVVZ/siLfc73mWn+cGP1PE1PKPruRSA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/web-bluetooth": "^0.0.20",
+                "@vueuse/metadata": "11.2.0",
+                "@vueuse/shared": "11.2.0",
+                "vue-demi": ">=0.14.10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "website/node_modules/@vueuse/core/node_modules/vue-demi": {
+            "version": "0.14.10",
+            "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+            "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "vue-demi-fix": "bin/vue-demi-fix.js",
+                "vue-demi-switch": "bin/vue-demi-switch.js"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "@vue/composition-api": "^1.0.0-rc.1",
+                "vue": "^3.0.0-0 || ^2.6.0"
+            },
+            "peerDependenciesMeta": {
+                "@vue/composition-api": {
+                    "optional": true
+                }
+            }
+        },
+        "website/node_modules/@vueuse/metadata": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-11.2.0.tgz",
+            "integrity": "sha512-L0ZmtRmNx+ZW95DmrgD6vn484gSpVeRbgpWevFKXwqqQxW9hnSi2Ppuh2BzMjnbv4aJRiIw8tQatXT9uOB23dQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "website/node_modules/@vueuse/shared": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-11.2.0.tgz",
+            "integrity": "sha512-VxFjie0EanOudYSgMErxXfq6fo8vhr5ICI+BuE3I9FnX7ePllEsVrRQ7O6Q1TLgApeLuPKcHQxAXpP+KnlrJsg==",
+            "license": "MIT",
+            "dependencies": {
+                "vue-demi": ">=0.14.10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "website/node_modules/@vueuse/shared/node_modules/vue-demi": {
+            "version": "0.14.10",
+            "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+            "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "vue-demi-fix": "bin/vue-demi-fix.js",
+                "vue-demi-switch": "bin/vue-demi-switch.js"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "@vue/composition-api": "^1.0.0-rc.1",
+                "vue": "^3.0.0-0 || ^2.6.0"
+            },
+            "peerDependenciesMeta": {
+                "@vue/composition-api": {
+                    "optional": true
+                }
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "@types/wicg-file-system-access": "^2023.10.5",
         "@typescript-eslint/eslint-plugin": "^8.14.0",
         "@typescript-eslint/parser": "^8.14.0",
-        "eslint": "^9.15.0",
+        "eslint": "^9.14.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.1",
         "prettier": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
     },
     "devDependencies": {
         "@types/wicg-file-system-access": "^2023.10.5",
-        "@typescript-eslint/eslint-plugin": "^8.10.0",
-        "@typescript-eslint/parser": "^8.10.0",
-        "eslint": "^9.13.0",
+        "@typescript-eslint/eslint-plugin": "^8.14.0",
+        "@typescript-eslint/parser": "^8.14.0",
+        "eslint": "^9.15.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.1",
         "prettier": "^3.3.3",
         "typescript": "^5.6.3",
-        "typescript-eslint": "^8.10.0"
+        "typescript-eslint": "^8.14.0"
     },
     "prettier": {
         "tabWidth": 4,

--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
     },
     "devDependencies": {
         "@types/wicg-file-system-access": "^2023.10.5",
-        "@typescript-eslint/eslint-plugin": "^8.14.0",
-        "@typescript-eslint/parser": "^8.14.0",
-        "eslint": "^9.14.0",
+        "@typescript-eslint/eslint-plugin": "^8.15.0",
+        "@typescript-eslint/parser": "^8.15.0",
+        "eslint": "^9.15.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.1",
         "prettier": "^3.3.3",
         "typescript": "^5.6.3",
-        "typescript-eslint": "^8.14.0"
+        "typescript-eslint": "^8.15.0"
     },
     "prettier": {
         "tabWidth": 4,

--- a/packages/core/src/ast/stringLiteralExpression.ts
+++ b/packages/core/src/ast/stringLiteralExpression.ts
@@ -17,7 +17,7 @@ export class StringLiteralExpression extends Expression {
     /**
      * Creates a new StringLiteralExpression consisting out of a constant string
      *
-     * @param value the constant literal
+     * @param parts the parts of the string literal
      * @param metadata metadata for the expression
      */
     constructor(

--- a/packages/core/src/parser/cstToAstTransformer.ts
+++ b/packages/core/src/parser/cstToAstTransformer.ts
@@ -574,6 +574,9 @@ function parseString(value: string): string {
                 case '"':
                     res += '"';
                     break;
+                case "$":
+                    res += "$";
+                    break;
                 case "u": {
                     const code = value.substring(i + 1, i + 5);
                     res += String.fromCharCode(parseInt(code, 16));

--- a/packages/core/src/parser/cstToAstTransformer.ts
+++ b/packages/core/src/parser/cstToAstTransformer.ts
@@ -548,8 +548,8 @@ export function generateCstToAstTransfromer(parser: Parser): ICstVisitor<never, 
 }
 
 /**
- * Parses a string
- * Removes quotes and handles escapes
+ * Parses a string part
+ * Handles escapes
  *
  * @param value the string to parse
  * @returns the parsed string

--- a/packages/core/src/parser/lexer.ts
+++ b/packages/core/src/parser/lexer.ts
@@ -14,7 +14,7 @@ export enum Modes {
     IGNORE_NEW_LINE = "IGNORE_NEW_LINES",
     /**
      * Mode inside string literals
-     * Behaves significantly differnt from the other modes,
+     * Behaves significantly differently from the other modes,
      * as here, only string content, template expressions, and double quotes are matched.
      */
     STRING_LITERAL = "STRING_LITERAL"

--- a/packages/core/src/parser/lexer.ts
+++ b/packages/core/src/parser/lexer.ts
@@ -140,9 +140,9 @@ export const Comma = createToken({
  * Identifier token
  * Two types of identifiers exist:
  * - textual identifiers
- *  - can contain alphanumerical characters, underscore and dollar signs
+ *  - can contain ID_Continue characters, underscore and dollar signs
+ *  - must start with an ID_Start character, dollar sign or underscore
  *  - must not start with a number
- *  - must contain at least one alphanumerical character
  * - special characters identifiers
  *  - can contain all special characters EXCEPT
  *    - single dot (two or more dots are allowed)
@@ -151,12 +151,20 @@ export const Comma = createToken({
  *    - round/curly/square brackets
  *    - double quotes
  *    - /*, *\/, //
- *  - if there are trailing underscores or dollar signs, those are only part if afterwards there is no alphnumerical character
+ *  - if there are trailing underscores or dollar signs, those are only part if afterwards there is no ID_Continue character (except underscore)
  *    - otherwise these are part of the next textual identifier
  */
 export const Identifier = createToken({
     name: TokenType.IDENTIFIER,
-    pattern: /(([!#%&'+\-:;<=>?@\\^`|~]|\*(?!\/)|\/(?![/*])|\.{2,}|([_$](?![_$]*[a-z0-9])))+)|([a-z_$][a-z0-9_$]*)/i
+    pattern: {
+        exec: (text, startOffset) => {
+            const pattern =
+                /(([!#%&'+\-:;<=>?@\\^`|~]|\*(?!\/)|\/(?![/*])|\.{2,}|[$_]+(?![\p{ID_Continue}$]))+)|([\p{ID_Start}_$][\p{ID_Continue}$]*)/uy;
+            pattern.lastIndex = startOffset;
+            return pattern.exec(text);
+        }
+    },
+    line_breaks: false
 });
 
 /**

--- a/packages/core/src/parser/lexer.ts
+++ b/packages/core/src/parser/lexer.ts
@@ -11,7 +11,11 @@ export enum Modes {
     /**
      * Skip newlines in cst
      */
-    IGNORE_NEW_LINE = "IGNORE_NEW_LINES"
+    IGNORE_NEW_LINE = "IGNORE_NEW_LINES",
+    /**
+     * Mode inside
+     */
+    STRING_LITERAL = "STRING_LITERAL"
 }
 
 /**
@@ -32,7 +36,10 @@ export enum TokenType {
     IDENTIFIER = "Identifier",
     SIGN_MINUS = "SignMinus",
     EQUAL = "Equal",
-    STRING = "String",
+    STRING_CONTENT = "StringContent",
+    STRING_TEMPLATE_START = "StringTemplateStart",
+    STRING_START = "StringStart",
+    STRING_END = "StringEnd",
     NUMBER = "Number",
     SINGLE_LINE_COMMENT = "SingleLineComment",
     MULTI_LINE_COMMENT = "MultiLineComment"
@@ -189,19 +196,47 @@ export const Equal = createToken({
 });
 
 /**
- * String literal token
- * Must be enclosed in double quotes
+ * Content for a string literal except template expressions
  * The following characters must be escaped with a backslash:
  * - double quotes
  * - backslash
+ * - dollar sign if followed by opening curly brackets
+ *   - can be escaped even if not followed by opening curly brackets
  * Other supported escapes:
  * - n (newline)
  * - t (tab)
  * - u followed by 4 hexadecimal digits (unicode character)
  */
-export const String = createToken({
-    name: TokenType.STRING,
-    pattern: /"((\\([\\"nt]|u[0-9a-fA-F]{4}))|([a-zA-Z0-9!#$%&'()*+,\-./:;<=>?@[\]^_`{|}~ ]))*"/
+export const StringContent = createToken({
+    name: TokenType.STRING_CONTENT,
+    pattern: /([^\\$"\n]|\\([\\$"nt]|u[0-9a-fA-F]{4})|\$(?!\{))+/
+});
+
+/**
+ * Start of a template expression inside a string literal
+ */
+export const StringTemplateStart = createToken({
+    name: TokenType.STRING_TEMPLATE_START,
+    pattern: /\${/,
+    push_mode: Modes.IGNORE_NEW_LINE
+});
+
+/**
+ * String literal start token
+ */
+export const StringStart = createToken({
+    name: TokenType.STRING_START,
+    pattern: /"/,
+    push_mode: Modes.STRING_LITERAL
+});
+
+/**
+ * String template end token
+ */
+export const StringEnd = createToken({
+    name: TokenType.STRING_END,
+    pattern: /"/,
+    pop_mode: true
 });
 
 /**
@@ -248,7 +283,7 @@ const standardTokens = [
     Equal,
     SignMinus,
     Identifier,
-    String,
+    StringStart,
     Number,
     SingleLineComment,
     MultiLineComment
@@ -261,6 +296,7 @@ export const lexerDefinition: IMultiModeLexerDefinition = {
     defaultMode: Modes.DEFAULT,
     modes: {
         [Modes.DEFAULT]: [...standardTokens, NewLine],
-        [Modes.IGNORE_NEW_LINE]: [...standardTokens, SkippedNewLine]
+        [Modes.IGNORE_NEW_LINE]: [...standardTokens, SkippedNewLine],
+        [Modes.STRING_LITERAL]: [StringContent, StringTemplateStart, StringEnd]
     }
 };

--- a/packages/core/src/parser/lexer.ts
+++ b/packages/core/src/parser/lexer.ts
@@ -13,7 +13,9 @@ export enum Modes {
      */
     IGNORE_NEW_LINE = "IGNORE_NEW_LINES",
     /**
-     * Mode inside
+     * Mode inside string literals
+     * Behaves significantly differnt from the other modes,
+     * as here, only string content, template expressions, and double quotes are matched.
      */
     STRING_LITERAL = "STRING_LITERAL"
 }

--- a/packages/core/src/runtime/ast/executableStringLiteralExpression.ts
+++ b/packages/core/src/runtime/ast/executableStringLiteralExpression.ts
@@ -35,7 +35,7 @@ export class ExecutableStringLiteralExpression extends ExecutableExpression<Stri
                 let evaluationResultValue = evaluationResult.value;
                 let toString: BaseObject | undefined;
                 if (!evaluationResultValue.isNull) {
-                    evaluationResultValue.getFieldValue("toString", context);
+                    toString = evaluationResultValue.getFieldValue("toString", context);
                 }
 
                 if (toString instanceof AbstractFunctionObject) {

--- a/packages/core/src/runtime/ast/executableStringLiteralExpression.ts
+++ b/packages/core/src/runtime/ast/executableStringLiteralExpression.ts
@@ -1,5 +1,6 @@
 import { StringLiteralExpression } from "../../ast/stringLiteralExpression.js";
 import { InterpreterContext } from "../interpreter/interpreterContext.js";
+import { AbstractFunctionObject } from "../objects/functionObject.js";
 import { LabeledValue } from "../objects/labeledValue.js";
 import { StringObject } from "../objects/stringObject.js";
 import { SemanticFieldNames } from "../semanticFieldNames.js";
@@ -33,7 +34,7 @@ export class ExecutableStringLiteralExpression extends ExecutableExpression<Stri
                 let evaluationResultValue = evaluationResult.value;
                 const toString = evaluationResultValue.getFieldValue("toString", context);
 
-                if (toString) {
+                if (toString instanceof AbstractFunctionObject) {
                     evaluationResultValue = toString.invoke(
                         [{ name: SemanticFieldNames.SELF, value: new ExecutableConstExpression(evaluationResult) }],
                         context,

--- a/packages/core/src/runtime/ast/executableStringLiteralExpression.ts
+++ b/packages/core/src/runtime/ast/executableStringLiteralExpression.ts
@@ -1,5 +1,6 @@
 import { StringLiteralExpression } from "../../ast/stringLiteralExpression.js";
 import { InterpreterContext } from "../interpreter/interpreterContext.js";
+import { BaseObject } from "../objects/baseObject.js";
 import { AbstractFunctionObject } from "../objects/functionObject.js";
 import { LabeledValue } from "../objects/labeledValue.js";
 import { StringObject } from "../objects/stringObject.js";
@@ -32,7 +33,10 @@ export class ExecutableStringLiteralExpression extends ExecutableExpression<Stri
             } else {
                 const evaluationResult = part.expression.evaluate(context);
                 let evaluationResultValue = evaluationResult.value;
-                const toString = evaluationResultValue.getFieldValue("toString", context);
+                let toString: BaseObject | undefined;
+                if (!evaluationResultValue.isNull) {
+                    evaluationResultValue.getFieldValue("toString", context);
+                }
 
                 if (toString instanceof AbstractFunctionObject) {
                     evaluationResultValue = toString.invoke(

--- a/packages/core/src/runtime/ast/executableStringLiteralExpression.ts
+++ b/packages/core/src/runtime/ast/executableStringLiteralExpression.ts
@@ -2,13 +2,60 @@ import { StringLiteralExpression } from "../../ast/stringLiteralExpression.js";
 import { InterpreterContext } from "../interpreter/interpreterContext.js";
 import { LabeledValue } from "../objects/labeledValue.js";
 import { StringObject } from "../objects/stringObject.js";
-import { ExecutableLiteralExpression } from "./executableLiteralExpression.js";
+import { SemanticFieldNames } from "../semanticFieldNames.js";
+import { ExecutableConstExpression } from "./executableConstExpression.js";
+import { ExecutableExpression } from "./executableExpression.js";
 
 /**
  * Executable StringLiteralExpression
  */
-export class ExecutableStringLiteralExpression extends ExecutableLiteralExpression<StringLiteralExpression> {
+export class ExecutableStringLiteralExpression extends ExecutableExpression<StringLiteralExpression> {
+    /**
+     * Creates a new ExecutableStringLiteralExpression
+     *
+     * @param expression the expression this represents
+     * @param parts the parts of the string literal
+     */
+    constructor(
+        expression: StringLiteralExpression | undefined,
+        readonly parts: ExecutableStringLiteralPart[]
+    ) {
+        super(expression);
+    }
+
     override evaluateInternal(context: InterpreterContext): LabeledValue {
-        return { value: new StringObject(this.value, context.stringPrototype) };
+        let value: string = "";
+        for (const part of this.parts) {
+            if ("content" in part) {
+                value += part.content;
+            } else {
+                const evaluationResult = part.expression.evaluate(context);
+                let evaluationResultValue = evaluationResult.value;
+                const toString = evaluationResultValue.getFieldValue("toString", context);
+
+                if (toString) {
+                    evaluationResultValue = toString.invoke(
+                        [{ name: SemanticFieldNames.SELF, value: new ExecutableConstExpression(evaluationResult) }],
+                        context,
+                        undefined,
+                        undefined
+                    ).value;
+                }
+                value += evaluationResultValue.toString(context);
+            }
+        }
+        return { value: new StringObject(value, context.stringPrototype) };
     }
 }
+
+/**
+ * A part of a string literal
+ * Either a content string or a template expression
+ */
+export type ExecutableStringLiteralPart =
+    | {
+          content: string;
+      }
+    | {
+          expression: ExecutableExpression;
+      };

--- a/packages/core/src/runtime/executableAstHelper.ts
+++ b/packages/core/src/runtime/executableAstHelper.ts
@@ -38,7 +38,7 @@ export function id(identifier: string): ExecutableIdentifierExpression {
  * @returns the created literal expression
  */
 export function str(value: string): ExecutableStringLiteralExpression {
-    return new ExecutableStringLiteralExpression(undefined, value);
+    return new ExecutableStringLiteralExpression(undefined, [{ content: value }]);
 }
 
 /**

--- a/packages/core/src/runtime/runtimeAstTransformer.ts
+++ b/packages/core/src/runtime/runtimeAstTransformer.ts
@@ -146,7 +146,16 @@ export class RuntimeAstTransformer extends ASTVisitor<undefined, ExecutableExpre
     }
 
     override visistStringLiteralExpression(expression: StringLiteralExpression): ExecutableExpression<any> {
-        return new ExecutableStringLiteralExpression(this.optionalExpression(expression), expression.value);
+        return new ExecutableStringLiteralExpression(
+            this.optionalExpression(expression),
+            expression.parts.map((part) => {
+                if ("content" in part) {
+                    return { content: part.content };
+                } else {
+                    return { expression: this.visit(part.expression) };
+                }
+            })
+        );
     }
 
     override visitObjectExpression(expression: ObjectExpression): ExecutableExpression<any> {

--- a/packages/core/src/stdlib/modules/operatorModule.ts
+++ b/packages/core/src/stdlib/modules/operatorModule.ts
@@ -20,7 +20,7 @@ export const operatorModule = InterpreterModule.create(
                 operator,
                 native(
                     (args, context) => {
-                        if (args.length == 3 && args[0].name === SemanticFieldNames.SELF) {
+                        if (args[0].name === SemanticFieldNames.SELF) {
                             args.shift();
                         }
                         if (args.length != 2 || args[0].name !== undefined || args[1].name !== undefined) {
@@ -135,7 +135,7 @@ export const operatorModule = InterpreterModule.create(
             "??",
             native(
                 (args, context) => {
-                    if (args.length == 3 && args[0].name === SemanticFieldNames.SELF) {
+                    if (args[0].name === SemanticFieldNames.SELF) {
                         args.shift();
                     }
                     if (args.length != 2 || args[0].name !== undefined || args[1].name !== undefined) {
@@ -162,7 +162,7 @@ export const operatorModule = InterpreterModule.create(
             "-",
             native(
                 (args, context) => {
-                    if (args.length == 3 && args[0].name === SemanticFieldNames.SELF) {
+                    if (args[0].name === SemanticFieldNames.SELF) {
                         args.shift();
                     }
                     if (

--- a/packages/diagram-render-pdf/package.json
+++ b/packages/diagram-render-pdf/package.json
@@ -15,7 +15,7 @@
     "dependencies": {
         "@hylimo/diagram": "^1.1.2",
         "@hylimo/diagram-render-svg": "^1.1.2",
-        "pdfkit": "^0.15.0"
+        "pdfkit": "^0.15.1"
     },
     "devDependencies": {
         "@types/pdfkit": "^0.13.5"

--- a/packages/diagram/src/module/diagrams/content/uml/classifier/propertiesAndMethods.ts
+++ b/packages/diagram/src/module/diagrams/content/uml/classifier/propertiesAndMethods.ts
@@ -118,12 +118,26 @@ export const propertiesAndMethodsModule = InterpreterModule.create(
  */
 export function convertStringOrIdentifier(expression: Expression): string {
     if (expression instanceof StringLiteralExpression) {
-        return expression.value;
+        return convertString(expression);
     } else if (expression instanceof IdentifierExpression) {
         return expression.identifier;
     } else {
         throw new RuntimeError("Expression is neither a string nor an identifier", expression);
     }
+}
+
+/**
+ * Converts a string literal expression to a string
+ * If the expression uses string template expressions, an error is thrown.
+ *
+ * @param expression the expression to convert
+ * @returns the string representation of the expression
+ */
+export function convertString(expression: StringLiteralExpression): string {
+    if (expression.parts.length > 1 || !("content" in expression.parts[0])) {
+        throw new RuntimeError("String template expressions are not supported here", expression);
+    }
+    return expression.parts[0]?.content ?? "";
 }
 
 /**
@@ -151,7 +165,7 @@ function convertNumberOrIdentifier(expression: Expression): string {
  */
 function convertMultiplicityElement(expression: Expression): string {
     if (expression instanceof StringLiteralExpression) {
-        return expression.value;
+        return convertString(expression);
     } else if (expression instanceof OperatorExpression && isRangeOperator(expression)) {
         const left = expression.left;
         const right = expression.right;

--- a/packages/language-server/src/completion/executableCompletionExpression.ts
+++ b/packages/language-server/src/completion/executableCompletionExpression.ts
@@ -243,6 +243,7 @@ export class ExecutableCompletionExpression extends ExecutableExpression<Express
             return key.toString();
         }
 
+        // eslint-disable-next-line no-control-regex
         const disallowedPattern = /[\\"\u0000-\u001f\u2028\u2029\u0085\u007f\n]|\$\{/g;
         const escapedKey = key.replaceAll(disallowedPattern, (match) => {
             if (match === "\n") {

--- a/packages/language-server/src/completion/executableCompletionExpression.ts
+++ b/packages/language-server/src/completion/executableCompletionExpression.ts
@@ -244,7 +244,7 @@ export class ExecutableCompletionExpression extends ExecutableExpression<Express
         }
 
         // eslint-disable-next-line no-control-regex
-        const disallowedPattern = /[\\"\u0000-\u001f\u2028\u2029\u0085\u007f\n]|\$\{/g;
+        const disallowedPattern = /[\\"\u0000-\u001f\u2028\u2029\u0085\u007f\n]|(\$\{)/g;
         const escapedKey = key.replaceAll(disallowedPattern, (match) => {
             if (match === "\n") {
                 return "\\n";

--- a/packages/language-server/src/completion/executableCompletionExpression.ts
+++ b/packages/language-server/src/completion/executableCompletionExpression.ts
@@ -16,7 +16,8 @@ import { CompletionItem } from "./completionItem.js";
 /**
  * Pattern for identifiers which can be used directly without indexing
  */
-const identifierPattern = /^((([!#%&'+\-:;<=>?@\\^`|~_$]|\*(?!\/)|\/(?![/*])|\.{2,})+)|([a-z_$][a-z0-9_$]*))$/i;
+const identifierPattern =
+    /^((([!#%&'+\-:;<=>?@\\^`|~]|\*(?!\/)|\/(?![/*])|\.{2,}|[$_]+(?![\p{ID_Continue}$]))+)|([\p{ID_Start}_$][\p{ID_Continue}$]*))$/u;
 
 /**
  * An expression which throws an CompletionError on evaluation
@@ -242,23 +243,23 @@ export class ExecutableCompletionExpression extends ExecutableExpression<Express
             return key.toString();
         }
 
-        const allowedPattern = /^[a-zA-Z0-9!#$%&'()*+,\-./:;<=>?@[\]^_`{|}~ ]$/;
-        const escapedKey = [...key]
-            .map((char) => {
-                if (allowedPattern.test(char)) {
-                    return char;
-                } else if (char === "\n") {
-                    return "\\n";
-                } else if (char === "\t") {
-                    return "\\t";
-                } else if (char === '"') {
-                    return '\\"';
-                } else {
-                    const code = char.charCodeAt(0);
-                    return "\\u" + code.toString(16).padStart(4, "0");
-                }
-            })
-            .join("");
+        const disallowedPattern = /[\\"\u0000-\u001f\u2028\u2029\u0085\u007f\n]|\$\{/g;
+        const escapedKey = key.replaceAll(disallowedPattern, (match) => {
+            if (match === "\n") {
+                return "\\n";
+            } else if (match === "\t") {
+                return "\\t";
+            } else if (match === '"') {
+                return '\\"';
+            } else if (match === "\\") {
+                return "\\\\";
+            } else if (match === "${") {
+                return "\\${";
+            } else {
+                const code = match.charCodeAt(0);
+                return "\\u" + code.toString(16).padStart(4, "0");
+            }
+        });
 
         return `"${escapedKey}"`;
     }

--- a/packages/language-server/src/format/printers.ts
+++ b/packages/language-server/src/format/printers.ts
@@ -12,6 +12,7 @@ const { group, indent, join, line, hardline, softline } = doc.builders;
  */
 export const printers: Record<Rules, ({ ctx, path, print }: PrintContext) => Doc> = {
     literal: printLiteral,
+    stringPart: printStringPart,
     function: printFunction,
     expressions: printExpressions,
     listEntry: printListEntry,
@@ -33,10 +34,9 @@ export const printers: Record<Rules, ({ ctx, path, print }: PrintContext) => Doc
  * @param ctx the children of the current CST node
  * @returns the formatteed literal
  */
-function printLiteral({ ctx }: PrintContext): Doc {
-    if (ctx.String) {
-        const token = ctx.String[0] as IToken;
-        return token.image;
+function printLiteral({ ctx, path, print }: PrintContext): Doc {
+    if (ctx.StringStart) {
+        return ['"', ...path.map(print, Rules.STRING_PART), '"'];
     } else {
         const token = ctx.Number[0] as IToken;
         if (ctx.SignMinus) {
@@ -44,6 +44,20 @@ function printLiteral({ ctx }: PrintContext): Doc {
         } else {
             return token.image;
         }
+    }
+}
+
+/**
+ * Formats a string part
+ *
+ * @param context prettier print context
+ * @returns the formatted string part
+ */
+function printStringPart({ ctx, path, print }: PrintContext): Doc {
+    if (ctx.StringContent) {
+        return ctx.StringContent[0].image;
+    } else {
+        return group(["${", indent([softline, ...path.map(print, Rules.EXPRESSION)]), softline, "}"]);
     }
 }
 

--- a/packages/wasm-libs/package.json
+++ b/packages/wasm-libs/package.json
@@ -13,7 +13,7 @@
         "build": "rollup -c"
     },
     "dependencies": {
-        "harfbuzzjs": "^0.4.2"
+        "harfbuzzjs": "^0.4.3"
     },
     "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.3.0",

--- a/website/.vitepress/util/language.ts
+++ b/website/.vitepress/util/language.ts
@@ -195,7 +195,16 @@ export const languageConfiguration: languages.LanguageConfiguration = {
         ["(", ")"],
         ["[", "]"],
         ["${", "}"]
-    ]
+    ],
+    colorizedBracketPairs: [
+        ["{", "}"],
+        ["(", ")"],
+        ["[", "]"]
+    ],
+    comments: {
+        lineComment: "//",
+        blockComment: ["/*", "*/"]
+    }
 };
 
 /**
@@ -211,7 +220,7 @@ export const customDarkTheme: editor.IStandaloneThemeData = {
         },
         {
             token: "entity.name.function",
-            foreground: "#DCDCAA"
+            foreground: "#dcdcaa"
         },
         {
             token: "variable",
@@ -231,7 +240,11 @@ export const customDarkTheme: editor.IStandaloneThemeData = {
         },
         {
             token: "constant.numerical",
-            foreground: "#DCDCAA"
+            foreground: "#dcdcaa"
+        },
+        {
+            token: "delimiter.curly",
+            foreground: "#569cd6"
         }
     ],
     colors: {}
@@ -271,6 +284,10 @@ export const customLightTheme: editor.IStandaloneThemeData = {
         {
             token: "constant.numerical",
             foreground: "#098658"
+        },
+        {
+            token: "delimiter.curly",
+            foreground: "#0000ff"
         }
     ],
     colors: {}

--- a/website/.vitepress/util/language.ts
+++ b/website/.vitepress/util/language.ts
@@ -27,7 +27,6 @@ export const monarchTokenProvider: languages.IMonarchLanguage = {
             [/[0-9]+(\.[0-9]+)?([eE]-?[0-9]+)?/u, { token: "constant.numerical", switchTo: "@expression.after" }],
 
             // strings
-            [/"([^"\\]|\\.)*$/u, "string.invalid"], // non-teminated string
             [/"/u, { token: "string.quote", bracket: "@open", switchTo: "@string" }],
 
             // open brackets
@@ -42,9 +41,8 @@ export const monarchTokenProvider: languages.IMonarchLanguage = {
             [
                 /\{/u,
                 {
-                    token: "delimiter.curly.open",
-                    bracket: "@open",
-                    switchTo: "@expression"
+                    token: "@rematch",
+                    switchTo: "@expression.after"
                 }
             ],
             [
@@ -70,7 +68,7 @@ export const monarchTokenProvider: languages.IMonarchLanguage = {
                 {
                     token: "delimiter.curly.close",
                     bracket: "@close",
-                    switchTo: "@expression.after"
+                    next: "@pop"
                 }
             ],
             [
@@ -108,6 +106,16 @@ export const monarchTokenProvider: languages.IMonarchLanguage = {
                 }
             ],
 
+            // open curly bracket
+            [
+                /\{/u,
+                {
+                    token: "delimiter.curly.open",
+                    bracket: "@open",
+                    next: "@expression"
+                }
+            ],
+
             // else
             { include: "@expression" }
         ],
@@ -131,12 +139,22 @@ export const monarchTokenProvider: languages.IMonarchLanguage = {
                 }
             ],
 
+            // open curly bracket
+            [
+                /\{/u,
+                {
+                    token: "@rematch",
+                    switchTo: "@expression.after"
+                }
+            ],
+
             // else
             { include: "@expression.after" }
         ],
 
         string: [
-            [/[a-zA-Z0-9!#$%&'()*+,\-./:;<=>?@[\]^_`{|}~ ]+/u, "string"],
+            [/\$\{/u, { token: "delimiter.curly.open", bracket: "@open", next: "@expression" }],
+            [/([^\\$"\n]|\$(?!\{))+/u, "string"],
             [/\\([\\"nt]|u[0-9a-fA-F]{4})/u, "string.escape"],
             [/\\./u, "string.escape.invalid"],
             [/"/u, { token: "string.quote", bracket: "@close", switchTo: "@expression.after" }]
@@ -175,7 +193,8 @@ export const languageConfiguration: languages.LanguageConfiguration = {
     brackets: [
         ["{", "}"],
         ["(", ")"],
-        ["[", "]"]
+        ["[", "]"],
+        ["${", "}"]
     ]
 };
 

--- a/website/.vitepress/util/language.ts
+++ b/website/.vitepress/util/language.ts
@@ -7,31 +7,32 @@ export const monarchTokenProvider: languages.IMonarchLanguage = {
     defaultToken: "default",
     includeLF: true,
     start: "expression",
+    unicode: true,
 
     tokenizer: {
         expression: [
             //function call
             [
-                /((([!#%&'+\-:;<=>?@\\^`|~]|\*(?!\/)|\/(?![/*])|\.{2,}|([_$](?![_$]*[a-zA-Z0-9])))+)|([a-zA-Z_$][a-zA-Z0-9_$]*)(?=[^\S\n]*[{(]))/,
+                /((([!#%&'+\-:;<=>?@\\^`|~]|\*(?!\/)|\/(?![/*])|\.{2,}|[$_]+(?![\p{ID_Continue}$]))+)|([\p{ID_Start}_$][\p{ID_Continue}$]*)(?=[^\S\n]*[{(]))/u,
                 { token: "entity.name.function", switchTo: "@expression.after" }
             ],
 
             //variable
             [
-                /(([!#%&'+\-:;<=>?@\\^`|~]|\*(?!\/)|\/(?![/*])|\.{2,}|([_$](?![_$]*[a-zA-Z0-9])))+)|([a-zA-Z_$][a-zA-Z0-9_$]*)/,
+                /(([!#%&'+\-:;<=>?@\\^`|~]|\*(?!\/)|\/(?![/*])|\.{2,}|[$_]+(?![\p{ID_Continue}$]))+)|([\p{ID_Start}_$][\p{ID_Continue}$]*)/u,
                 { token: "variable", switchTo: "@expression.after" }
             ],
 
             // number
-            [/[0-9]+(\.[0-9]+)?([eE]-?[0-9]+)?/, { token: "constant.numerical", switchTo: "@expression.after" }],
+            [/[0-9]+(\.[0-9]+)?([eE]-?[0-9]+)?/u, { token: "constant.numerical", switchTo: "@expression.after" }],
 
             // strings
-            [/"([^"\\]|\\.)*$/, "string.invalid"], // non-teminated string
-            [/"/, { token: "string.quote", bracket: "@open", switchTo: "@string" }],
+            [/"([^"\\]|\\.)*$/u, "string.invalid"], // non-teminated string
+            [/"/u, { token: "string.quote", bracket: "@open", switchTo: "@string" }],
 
             // open brackets
             [
-                /\(/,
+                /\(/u,
                 {
                     token: "delimiter.round.open",
                     bracket: "@open",
@@ -39,7 +40,7 @@ export const monarchTokenProvider: languages.IMonarchLanguage = {
                 }
             ],
             [
-                /{/,
+                /\{/u,
                 {
                     token: "delimiter.curly.open",
                     bracket: "@open",
@@ -47,7 +48,7 @@ export const monarchTokenProvider: languages.IMonarchLanguage = {
                 }
             ],
             [
-                /\[/,
+                /\[/u,
                 {
                     token: "delimiter.square.open",
                     bracket: "@open",
@@ -57,7 +58,7 @@ export const monarchTokenProvider: languages.IMonarchLanguage = {
 
             // close brackets
             [
-                /\)/,
+                /\)/u,
                 {
                     token: "delimiter.round.close",
                     bracket: "@close",
@@ -65,7 +66,7 @@ export const monarchTokenProvider: languages.IMonarchLanguage = {
                 }
             ],
             [
-                /}/,
+                /\}/u,
                 {
                     token: "delimiter.curly.close",
                     bracket: "@close",
@@ -73,7 +74,7 @@ export const monarchTokenProvider: languages.IMonarchLanguage = {
                 }
             ],
             [
-                /]/,
+                /\]/u,
                 {
                     token: "delimiter.square.close",
                     bracket: "@close",
@@ -82,25 +83,25 @@ export const monarchTokenProvider: languages.IMonarchLanguage = {
             ],
 
             // comma
-            [/,/, { token: "delimiter.comma", switchTo: "@expression" }],
+            [/,/u, { token: "delimiter.comma", switchTo: "@expression" }],
 
             // whitespace
             { include: "@whitespace" },
 
             //newline
-            [/\n/, "white"]
+            [/\n/u, "white"]
         ],
 
         "expression.after": [
             // dot
-            [/\.(?!\.)/, { token: "delimiter.dot", switchTo: "@expression.after.access" }],
+            [/\.(?!\.)/u, { token: "delimiter.dot", switchTo: "@expression.after.access" }],
 
             // newline
             [/\n/, { token: "white", switchTo: "@expression" }],
 
             // variable
             [
-                /((([!#%&'+\-:;<=>?@\\^`|~]|\*(?!\/)|\/(?![/*])|\.{2,}|([_$](?![_$]*[a-zA-Z0-9])))+)|([a-zA-Z_$][a-zA-Z0-9_$]*|\.)+)/,
+                /((([!#%&'+\-:;<=>?@\\^`|~]|\*(?!\/)|\/(?![/*])|\.{2,}|([_$](?![_$]*[a-zA-Z0-9])))+)|([a-zA-Z_$][a-zA-Z0-9_$]*|\.)+)/u,
                 {
                     token: "operator",
                     switchTo: "@expression"
@@ -114,7 +115,7 @@ export const monarchTokenProvider: languages.IMonarchLanguage = {
         "expression.after.access": [
             //function call
             [
-                /((([!#%&'+\-:;<=>?@\\^`|~]|\*(?!\/)|\/(?![/*])|\.{2,}|([_$](?![_$]*[a-zA-Z0-9])))+)|([a-zA-Z_$][a-zA-Z0-9_$]*)(?=[^\S\n]*[{(]))/,
+                /((([!#%&'+\-:;<=>?@\\^`|~]|\*(?!\/)|\/(?![/*])|\.{2,}|[$_]+(?![\p{ID_Continue}$]))+)|([\p{ID_Start}_$][\p{ID_Continue}$]*)(?=[^\S\n]*[{(]))/u,
                 {
                     token: "entity.name.function",
                     switchTo: "expression.after"
@@ -123,7 +124,7 @@ export const monarchTokenProvider: languages.IMonarchLanguage = {
 
             //variable
             [
-                /(([!#%&'+\-:;<=>?@\\^`|~]|\*(?!\/)|\/(?![/*])|\.{2,}|([_$](?![_$]*[a-zA-Z0-9])))+)|([a-zA-Z_$][a-zA-Z0-9_$]*)/,
+                /(([!#%&'+\-:;<=>?@\\^`|~]|\*(?!\/)|\/(?![/*])|\.{2,}|[$_]+(?![\p{ID_Continue}$]))+)|([\p{ID_Start}_$][\p{ID_Continue}$]*)/u,
                 {
                     token: "variable.property",
                     switchTo: "@expression.after"
@@ -135,22 +136,22 @@ export const monarchTokenProvider: languages.IMonarchLanguage = {
         ],
 
         string: [
-            [/[a-zA-Z0-9!#$%&'()*+,\-./:;<=>?@[\]^_`{|}~ ]+/, "string"],
-            [/\\([\\"nt]|u[0-9a-fA-F]{4})/, "string.escape"],
-            [/\\./, "string.escape.invalid"],
-            [/"/, { token: "string.quote", bracket: "@close", switchTo: "@expression.after" }]
+            [/[a-zA-Z0-9!#$%&'()*+,\-./:;<=>?@[\]^_`{|}~ ]+/u, "string"],
+            [/\\([\\"nt]|u[0-9a-fA-F]{4})/u, "string.escape"],
+            [/\\./u, "string.escape.invalid"],
+            [/"/u, { token: "string.quote", bracket: "@close", switchTo: "@expression.after" }]
         ],
 
         whitespace: [
-            [/[^\S\n]+/, "white"],
-            [/\/\*/, "comment", "@comment"],
-            [/\/\/.*/, "comment"]
+            [/[^\S\n]+/u, "white"],
+            [/\/\*/u, "comment", "@comment"],
+            [/\/\/.*/u, "comment"]
         ],
 
         comment: [
-            [/[^/*]+/, "comment"],
-            [/\*\//, "comment", "@pop"],
-            [/[/*]/, "comment"]
+            [/[^/*]+/u, "comment"],
+            [/\*\//u, "comment", "@pop"],
+            [/[/*]/u, "comment"]
         ]
     }
 };

--- a/website/package.json
+++ b/website/package.json
@@ -15,8 +15,8 @@
         "@types/pako": "^2.0.3",
         "@types/uuid": "^10.0.0",
         "@vite-pwa/vitepress": "^0.5.3",
-        "vitepress": "^1.4.1",
-        "vue": "^3.5.12"
+        "vitepress": "^1.5.0",
+        "vue": "^3.5.13"
     },
     "dependencies": {
         "@hylimo/core": "^1.1.2",
@@ -24,7 +24,7 @@
         "@hylimo/diagram-render-svg": "^1.1.2",
         "@hylimo/diagram-ui": "^1.1.2",
         "@hylimo/language-server": "^1.1.2",
-        "@vueuse/core": "^11.1.0",
+        "@vueuse/core": "^11.2.0",
         "file-saver": "^2.0.5",
         "js-base64": "^3.7.7",
         "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@~8.0.4",
@@ -34,7 +34,7 @@
         "reflect-metadata": "^0.2.2",
         "splitpanes": "^3.1.5",
         "sprotty": "^1.3.0",
-        "uuid": "^10.0.0",
+        "uuid": "^11.0.3",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-protocol": "^3.17.5"
     }


### PR DESCRIPTION
## technical changes
- update dependencies
- syntax highlighting now uses a type 2 grammar

## new features
- template expressions in strings
- unicode support for string literals and identifiers
- add comment support to textual editor (e.g. Ctrl + # for line comment)

## bug fixes
- lexer errors were not shown

## breaking changes
- `${` now is treated as a template in strings

## issues
- closes #90 