### PR TITLE
fix bug in format and using variables in styles

### DIFF
--- a/packages/diagram/src/module/base/dslModule.ts
+++ b/packages/diagram/src/module/base/dslModule.ts
@@ -180,6 +180,7 @@ const scopeExpressions: ParseableExpressions = [
                             selectorValue = className,
                             styles = list(),
                             class = first.class,
+                            variables = [],
                             ${allStyleAttributes.map((attr) => `${attr.name} = null`).join(",")}
                         ],
                         true

--- a/packages/language-server/src/format/printers.ts
+++ b/packages/language-server/src/format/printers.ts
@@ -36,7 +36,11 @@ export const printers: Record<Rules, ({ ctx, path, print }: PrintContext) => Doc
  */
 function printLiteral({ ctx, path, print }: PrintContext): Doc {
     if (ctx.StringStart) {
-        return ['"', ...path.map(print, Rules.STRING_PART), '"'];
+        if (ctx.stringPart) {
+            return ['"', ...path.map(print, Rules.STRING_PART), '"'];
+        } else {
+            return '""';
+        }
     } else {
         const token = ctx.Number[0] as IToken;
         if (ctx.SignMinus) {


### PR DESCRIPTION
## bugfixes

- empty strings no longer result in a formatter error
- variables can be used again directly inside the styles scope