### PR TITLE
Support `as` on participants

### DIFF
--- a/packages/diagram/src/module/diagrams/content/uml/sequence/sequenceDiagramActor.ts
+++ b/packages/diagram/src/module/diagrams/content/uml/sequence/sequenceDiagramActor.ts
@@ -28,8 +28,11 @@ export const sequenceDiagramActorModule = InterpreterModule.create(
                     // We don't want to display the actor name when attributes are present. That will be handled by the underlying instance
                     actorName = if(callback != null) { null } { originalName }
                     this.actor = scope.internal.createActor(actorName, args = args)
-                    name = originalName
-                    
+
+                    // Allow overriding the name to something easier to read for the textual syntax in the text by setting 'as'
+                    // After all, the actor name may often contain '-' or ' ' as it is user visible input
+                    name = if(argsCopy.as != null) { argsCopy.as } { originalName }
+ 
                     // Actors have an optional name, so we must supply one for the first actor for the first actor in the diagram for example for arrows: 'event.User --> event.Shop' or 'activate(User)'
                     // Note however, that this name should not be displayed, so it cannot be done before the actor was created
                     if(name == null) {
@@ -67,6 +70,11 @@ export const sequenceDiagramActorModule = InterpreterModule.create(
                             "below",
                             "the optional participant below which the actor should be placed. If set, this actor will have the same x coordinate as the given value and the y coordinate of the current event",
                             optional(participantType)
+                        ],
+                        [
+                            "as",
+                            "an optional name of this actor for the textual syntax. Should be set when the name contains special chars, i.e. '-' or ' ', to make the textual syntax more readable",
+                            optional(stringType)
                         ]
                     ],
                     snippet: `($1)`,

--- a/packages/diagram/src/module/diagrams/content/uml/sequence/sequenceDiagramInstance.ts
+++ b/packages/diagram/src/module/diagrams/content/uml/sequence/sequenceDiagramInstance.ts
@@ -30,6 +30,14 @@ export const sequenceDiagramInstanceModule = InterpreterModule.create(
                         }
                     }
                     this.instance = scope.internal.createInstance(name, callback, title = title, keywords = args.keywords, args = args)
+                    
+                    // Allow using an easier name for instances when the instance name contains special chars, i.e. '-' or ' ' which can happen in user-visible content
+                    argsCopy = args
+                    if(argsCopy.as != null) {
+                        name = argsCopy.as
+                        scope.internal.registerInDiagramScope(name, instance)
+                    }
+                    
                     scope.internal.createSequenceDiagramParticipant(name, this.instance, below = args.below)
                 `,
                 {
@@ -46,6 +54,11 @@ export const sequenceDiagramInstanceModule = InterpreterModule.create(
                             "below",
                             "the optional participant below which the instance should be placed. If set, this instance will have the same x coordinate as the given value and the y coordinate of the current event",
                             optional(participantType)
+                        ],
+                        [
+                            "as",
+                            "an optional name to use for the textual syntax for when the instance name contains special chars such as '-' or ' '",
+                            optional(stringType)
                         ]
                     ],
                     snippet: `("$1"$2)`,

--- a/website/docs/sequence.md
+++ b/website/docs/sequence.md
@@ -105,7 +105,7 @@ If their name is already used by something else, you can assign the result of th
 sequenceDiagram {
     enableDebugging = true
     Bob = true
-    user = instance("Bob")
+    instance("Bob")
     event("buy")
     event("stop")
     buy.Bob --> stop.Bob with {
@@ -117,6 +117,47 @@ sequenceDiagram {
 :::
 
 In this example, we also see that to refer to a specific xy-coordinate, we can always use `eventname.participant`.
+
+From time to time, we need to display names containing special chars.\
+While Hylimo itself can handle this just fine, it is unpleasant to look at and write:
+
+:::info
+
+```hylimo
+sequenceDiagram {
+    instance("An instance")
+    event("ugly event name")
+    event("stop")
+    this["ugly event name"]["An instance"] --> stop["An instance"] with {
+        over = start(0).axisAligned(1, apos(0, 25), 1, apos(25, 25), 0, end(0.5))
+    }
+}
+```
+
+:::
+
+Since this is really ugly to look at and potentially unavoidable in the case of participants, Hylimo offers the following workaround to improve the readability:\
+Event names should never contain any special chars such as `-` or ` `. `_` is alright, or you use `pascalCaseForEventNames`.\
+You can easily do this as event names are never shown in the final diagram.\
+For participants, you can also pass `as` when creating it to give it a name of your own choosing that is only relevant for the textual syntax:
+
+:::info
+
+```hylimo
+sequenceDiagram {
+    instance("An instance", as = "bob")
+    event("doSomething")
+    event("stop")
+    doSomething.bob --> stop.bob with {
+        over = start(0).axisAligned(1, apos(0, 25), 1, apos(25, 25), 0, end(0.5))
+    }
+}
+```
+
+:::
+
+This one produces the same result but is a lot more readable.\
+Note, however, that you cannot access something using your original participant name anymore if you alias it.
 
 Now, we have the basic knowledge to go on with the remaining features that are all relative to the latest event.
 


### PR DESCRIPTION
In my first practical example of a use case diagram,
I had to use a name containing ` ` and immediately noticed that this case is a) quite common and b) a pain to maintain.
When `as` is set, it replaces the participant's name only in the textual syntax.
The diagram renders the same (given that you rename all mentions to this participant to its new alias), but events are much easier to use.