### PR TITLE
svg text as path

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -28,6 +28,7 @@ program
     .option("--max-execution-steps", "Maximum number of execution steps", parseInt, 1000000)
     .option("--disable-font-subsetting", "Disable font subsetting", false)
     .option("--enable-external-fonts", "Enable external fonts", false)
+    .option("--text-as-path", "Render text as path, only relevant for svg output format", false)
     .parse(process.argv);
 
 const options = program.opts();
@@ -80,7 +81,7 @@ const config: DiagramConfig = {
         fs.writeFileSync(outputFile, Buffer.from(renderedPdf.flatMap((part) => [...part])));
     } else if (outputExtension === ".svg") {
         const renderer = new SVGRenderer();
-        const svg = renderer.render(rootElement);
+        const svg = renderer.render(rootElement, options.textAsPath);
         fs.writeFileSync(outputFile, svg);
     }
 })();

--- a/packages/diagram-render-pdf/src/pdfRenderer.ts
+++ b/packages/diagram-render-pdf/src/pdfRenderer.ts
@@ -65,7 +65,6 @@ export class PDFDiagramVisitor extends SimplifiedDiagramVisitor<PDFKit.PDFDocume
      *
      * @param margin the margin to apply to the bounding box
      * @param background the background color
-     * @param fontCollection the font collection to use
      */
     constructor(
         private readonly margin: number,

--- a/packages/diagram-render-svg/src/svgRenderer.ts
+++ b/packages/diagram-render-svg/src/svgRenderer.ts
@@ -6,7 +6,8 @@ import {
     Element,
     convertFontsToCssStyle,
     Ellipse,
-    SimplifiedText
+    SimplifiedText,
+    FontData
 } from "@hylimo/diagram-common";
 import { SimplifiedDiagramVisitor } from "@hylimo/diagram-common";
 import {
@@ -18,33 +19,30 @@ import {
 import { SimplifiedCanvasElement } from "@hylimo/diagram-common";
 import { create } from "xmlbuilder2";
 import { XMLBuilder } from "xmlbuilder2/lib/interfaces.js";
+import { create as createFont, Font } from "fontkit";
+import { Buffer } from "buffer";
 
 /**
  * Renderer which renders a diagram to svg
  */
 export class SVGRenderer {
     /**
-     * Visitor to render the diagram to svg
-     */
-    private readonly visitor: SVGDiagramVisitor;
-
-    /**
      * Creates a new svg renderer
      *
      * @param margin the margin to apply to the bounding box
      */
-    constructor(margin = 10) {
-        this.visitor = new SVGDiagramVisitor(margin);
-    }
+    constructor(private readonly margin = 10) {}
 
     /**
      * Renders the provided root to an svg string
      *
      * @param root the diagram to render
+     * @param textAsPath whether to render text as path
      * @returns the svg string
      */
-    render(root: Root): string {
-        const svg = this.visitor.visit(root, undefined)[0];
+    render(root: Root, textAsPath: boolean): string {
+        const visitor = new SVGDiagramVisitor(this.margin, textAsPath);
+        const svg = visitor.visit(root, new SVGRendererContext(root))[0];
         const builder = create();
         this.toXml(svg, builder);
         return builder.doc().end({ prettyPrint: true });
@@ -96,33 +94,84 @@ type SVGNode =
       };
 
 /**
+ * Context for the SVGDiagramVisitor
+ */
+class SVGRendererContext {
+    /**
+     * Lookup for already loaded fonts
+     */
+    private readonly fonts: Map<string, Font> = new Map();
+
+    /**
+     * Lookup for font datas
+     */
+    private readonly fontDatas: Map<string, FontData>;
+
+    /**
+     * Creates a new svg renderer context
+     *
+     * @param root the root element of the diagram, provides the fonts
+     */
+    constructor(root: Root) {
+        this.fontDatas = new Map(root.fonts.map((fontData) => [fontData.fontFamily, fontData]));
+    }
+
+    /**
+     * Gets the font with the provided family
+     *
+     * @param fontFamily the family of the font
+     * @returns the font
+     * @throws if the font is not found
+     */
+    getFont(fontFamily: string): Font {
+        if (!this.fonts.has(fontFamily)) {
+            const fontData = this.fontDatas.get(fontFamily);
+            if (!fontData) {
+                throw new Error(`Font with family ${fontFamily} not found`);
+            }
+            const buffer = Buffer.from(fontData.data, "base64");
+            this.fonts.set(fontFamily, createFont(buffer) as Font);
+        }
+        return this.fonts.get(fontFamily)!;
+    }
+}
+
+/**
  * Visitor to render the diagram to svg
  */
-class SVGDiagramVisitor extends SimplifiedDiagramVisitor<undefined, SVGNode[]> {
+class SVGDiagramVisitor extends SimplifiedDiagramVisitor<SVGRendererContext, SVGNode[]> {
     /**
      * Creates a new svg diagram visitor
      *
      * @param margin the margin to apply to the bounding box
+     * @param textAsPath whether to render text as path
      */
-    constructor(private readonly margin: number) {
+    constructor(
+        private readonly margin: number,
+        private readonly textAsPath: boolean
+    ) {
         super();
     }
 
-    override visitRoot(element: Root): SVGNode[] {
+    override visitRoot(element: Root, context: SVGRendererContext): SVGNode[] {
         const viewBox = element.rootBounds;
         const x = viewBox.position.x - this.margin;
         const y = viewBox.position.y - this.margin;
         const width = viewBox.size.width + this.margin * 2;
         const height = viewBox.size.height + this.margin * 2;
+        let styles = "text { white-space: pre; }\n";
+        if (!this.textAsPath) {
+            styles += convertFontsToCssStyle(element.fonts);
+        }
         const additionalChildren: SVGNode[] = [
             {
                 type: "style",
-                children: ["text { white-space: pre; }\n" + convertFontsToCssStyle(element.fonts)]
+                children: [styles]
             }
         ];
         const result = {
             type: "svg",
-            children: [...additionalChildren, ...this.visitChildren(element)],
+            children: [...additionalChildren, ...this.visitChildren(element, context)],
             viewBox: `${x} ${y} ${width} ${height}`,
             width,
             height,
@@ -131,7 +180,7 @@ class SVGDiagramVisitor extends SimplifiedDiagramVisitor<undefined, SVGNode[]> {
         return [result];
     }
 
-    override visitRect(element: Rect): SVGNode[] {
+    override visitRect(element: Rect, context: SVGRendererContext): SVGNode[] {
         const result: SVGNode = {
             type: "rect",
             children: [],
@@ -141,10 +190,10 @@ class SVGDiagramVisitor extends SimplifiedDiagramVisitor<undefined, SVGNode[]> {
             const strokeWidth = element.stroke?.width;
             result.rx = Math.max(0, element.cornerRadius - (strokeWidth ? strokeWidth / 2 : 0));
         }
-        return [result, ...this.visitChildren(element)];
+        return [result, ...this.visitChildren(element, context)];
     }
 
-    override visitEllipse(element: Ellipse): SVGNode[] {
+    override visitEllipse(element: Ellipse, context: SVGRendererContext): SVGNode[] {
         const strokeWidth = element.stroke?.width ?? 0;
         const result: SVGNode = {
             type: "ellipse",
@@ -155,7 +204,7 @@ class SVGDiagramVisitor extends SimplifiedDiagramVisitor<undefined, SVGNode[]> {
             rx: (element.width - strokeWidth) / 2,
             ry: (element.height - strokeWidth) / 2
         };
-        return [result, ...this.visitChildren(element)];
+        return [result, ...this.visitChildren(element, context)];
     }
 
     override visitPath(element: Path): SVGNode[] {
@@ -169,8 +218,49 @@ class SVGDiagramVisitor extends SimplifiedDiagramVisitor<undefined, SVGNode[]> {
         return [result];
     }
 
-    override visitText(element: SimplifiedText): SVGNode[] {
-        const result: SVGNode = {
+    override visitText(element: SimplifiedText, context: SVGRendererContext): SVGNode[] {
+        return [
+            this.textAsPath ? this.renderTextAsPath(context, element) : this.renderTextAsText(element),
+            ...this.visitChildren(element, context)
+        ];
+    }
+
+    /**
+     * Renders a text element as path
+     *
+     * @param context the context to use
+     * @param element the text element to render
+     * @returns the svg node representing the text
+     */
+    private renderTextAsPath(context: SVGRendererContext, element: SimplifiedText): SVGNode {
+        const font = context.getFont(element.fontFamily);
+        const glyphRun = font.layout(element.text);
+        let offset = 0;
+        const paths: string[] = [];
+        for (const glyph of glyphRun.glyphs) {
+            if (!/^\s*$/.test(String.fromCodePoint(...glyph.codePoints)) && element.fill != undefined) {
+                paths.push(glyph.path.translate(offset, 0).toSVG());
+            }
+            offset += glyph.advanceWidth;
+        }
+        const scalingFactor = element.fontSize / font.unitsPerEm;
+        return {
+            type: "path",
+            children: [],
+            ...extractFillAttributes(element),
+            d: paths.join(" "),
+            transform: `translate(${element.x}, ${element.y}) scale(${scalingFactor}, ${-scalingFactor})`
+        };
+    }
+
+    /**
+     * Renders a text element as text
+     *
+     * @param element the text element to render
+     * @returns the svg node representing the text
+     */
+    private renderTextAsText(element: SimplifiedText): SVGNode {
+        return {
             type: "text",
             children: [element.text],
             ...extractLayoutAttributes(element),
@@ -178,24 +268,23 @@ class SVGDiagramVisitor extends SimplifiedDiagramVisitor<undefined, SVGNode[]> {
             "font-family": element.fontFamily,
             "font-size": element.fontSize
         };
-        return [result, ...this.visitChildren(element)];
     }
 
-    override visitCanvas(element: Canvas): SVGNode[] {
+    override visitCanvas(element: Canvas, context: SVGRendererContext): SVGNode[] {
         const result: SVGNode = {
             type: "g",
             transform: `translate(${element.dx}, ${element.dy})`,
-            children: this.visitChildren(element)
+            children: this.visitChildren(element, context)
         };
         return [result];
     }
 
-    override visitCanvasElement(element: SimplifiedCanvasElement): SVGNode[] {
+    override visitCanvasElement(element: SimplifiedCanvasElement, context: SVGRendererContext): SVGNode[] {
         const position = element.pos;
         const result: SVGNode = {
             type: "g",
             transform: `translate(${position.x}, ${position.y}) rotate(${element.rotation})`,
-            children: this.visitChildren(element)
+            children: this.visitChildren(element, context)
         };
         return [result];
     }
@@ -204,13 +293,10 @@ class SVGDiagramVisitor extends SimplifiedDiagramVisitor<undefined, SVGNode[]> {
      * Visists all children of the provided element and calls visitElement on them
      *
      * @param element the element to visit the children of
+     * @param context the context to use
      * @returns the result of the visit
      */
-    private visitChildren(element: Element): SVGNode[] {
-        return element.children.flatMap((child) => this.visitElement(child));
-    }
-
-    override visitElement(element: Element): SVGNode[] {
-        return super.visitElement(element, undefined);
+    private visitChildren(element: Element, context: SVGRendererContext): SVGNode[] {
+        return element.children.flatMap((child) => this.visitElement(child, context));
     }
 }

--- a/packages/diagram-render-svg/src/svgRenderer.ts
+++ b/packages/diagram-render-svg/src/svgRenderer.ts
@@ -159,16 +159,13 @@ class SVGDiagramVisitor extends SimplifiedDiagramVisitor<SVGRendererContext, SVG
         const y = viewBox.position.y - this.margin;
         const width = viewBox.size.width + this.margin * 2;
         const height = viewBox.size.height + this.margin * 2;
-        let styles = "text { white-space: pre; }\n";
+        const additionalChildren: SVGNode[] = [];
         if (!this.textAsPath) {
-            styles += convertFontsToCssStyle(element.fonts);
-        }
-        const additionalChildren: SVGNode[] = [
-            {
+            additionalChildren.push({
                 type: "style",
-                children: [styles]
-            }
-        ];
+                children: ["text { white-space: pre; }\n" + convertFontsToCssStyle(element.fonts)]
+            });
+        }
         const result = {
             type: "svg",
             children: [...additionalChildren, ...this.visitChildren(element, context)],

--- a/website/.vitepress/components/Home.vue
+++ b/website/.vitepress/components/Home.vue
@@ -19,7 +19,12 @@
             </Teleport>
             <Teleport to="#export-diagram">
                 <VPFlyout icon="vpi-download" label="Download diagram" class="download-flyout">
-                    <button class="menu-button" :disabled="diagram == undefined" @click="downloadSVG">SVG</button>
+                    <button class="menu-button" :disabled="diagram == undefined" @click="downloadSVG(false)">
+                        SVG
+                    </button>
+                    <button class="menu-button" :disabled="diagram == undefined" @click="downloadSVG(true)">
+                        SVG (text as path)
+                    </button>
                     <button class="menu-button" :disabled="diagram == undefined" @click="downloadPDF">PDF</button>
                     <button class="menu-button" @click="downloadSource">Source</button>
                 </VPFlyout>
@@ -98,8 +103,8 @@ onKeyStroke("E", (event) => {
     downloadSVG();
 });
 
-function downloadSVG() {
-    const svgBlob = new Blob([svgRenderer.render(diagram.value!)], { type: "image/svg+xml;charset=utf-8" });
+function downloadSVG(textAsPath: boolean) {
+    const svgBlob = new Blob([svgRenderer.render(diagram.value!, textAsPath)], { type: "image/svg+xml;charset=utf-8" });
     fileSaver.saveAs(svgBlob, baseName.value + ".svg");
 }
 


### PR DESCRIPTION
## new features
- add svg export where text is replaced by paths
  - for use cases where embedded font files are not allowed (e.g. PowerPoint)

## issues
- closes #103 