### PR TITLE
fix graphical segment splitting

### DIFF
--- a/packages/diagram-ui/src/features/split-canvas-segment/splitCanvasSegmentMouseListener.ts
+++ b/packages/diagram-ui/src/features/split-canvas-segment/splitCanvasSegmentMouseListener.ts
@@ -2,7 +2,14 @@ import { inject, injectable } from "inversify";
 import { MouseListener, SModelElementImpl } from "sprotty";
 import { Action } from "sprotty-protocol";
 import { SCanvasConnection } from "../../model/canvas/sCanvasConnection.js";
-import { DefaultEditTypes, LineEngine, Math2D, Point, ProjectionResult } from "@hylimo/diagram-common";
+import {
+    DefaultEditTypes,
+    EditSpecification,
+    LineEngine,
+    Math2D,
+    Point,
+    ProjectionResult
+} from "@hylimo/diagram-common";
 import { SCanvasConnectionSegment } from "../../model/canvas/sCanvasConnectionSegment.js";
 import {
     AxisAlignedSegmentEdit,
@@ -163,7 +170,8 @@ export class SplitCanvasSegmentMouseListener extends MouseListener {
             elements: [originSegment.id]
         } satisfies SplitCanvasAxisAlignedSegmentEdit);
         const editNextPos = originSegment.edits[DefaultEditTypes.AXIS_ALIGNED_SEGMENT_POS];
-        if (editNextPos != undefined) {
+        const splitSegment = originSegment.edits[DefaultEditTypes.SPLIT_CANVAS_AXIS_ALIGNED_SEGMENT];
+        if (editNextPos != undefined && EditSpecification.isConsistent([[editNextPos], [splitSegment]])) {
             edits.push({
                 types: [DefaultEditTypes.AXIS_ALIGNED_SEGMENT_POS],
                 values: {

--- a/packages/diagram-ui/src/model/canvas/sCanvasAxisAlignedSegment.ts
+++ b/packages/diagram-ui/src/model/canvas/sCanvasAxisAlignedSegment.ts
@@ -125,11 +125,6 @@ export class SCanvasAxisAlignedSegment
     }
 
     override canSplitSegment(): boolean {
-        const splitEdit = this.edits[DefaultEditTypes.SPLIT_CANVAS_AXIS_ALIGNED_SEGMENT];
-        if (!EditSpecification.isConsistent([[splitEdit]])) {
-            return false;
-        }
-        const nextPosEdit = this.edits[DefaultEditTypes.AXIS_ALIGNED_SEGMENT_POS];
-        return nextPosEdit == undefined || EditSpecification.isConsistent([[nextPosEdit], [splitEdit]]);
+        return EditSpecification.isConsistent([[this.edits[DefaultEditTypes.SPLIT_CANVAS_AXIS_ALIGNED_SEGMENT]]]);
     }
 }

--- a/packages/language-server/src/edit/transactionManager.ts
+++ b/packages/language-server/src/edit/transactionManager.ts
@@ -119,7 +119,7 @@ export class TransactionManager {
      */
     private createHandleActionResult(action: TransactionalAction): IncrementalUpdate[] {
         const currentDiagram = this.diagram.currentDiagram;
-        if (currentDiagram != undefined && this.edit != undefined) {
+        if (currentDiagram != undefined && this.edit != undefined && (action.sequenceNumber > 0 || !action.committed)) {
             return this.edit.predictActionDiff(this.diagram.currentDiagram!, this.lastAppliedAction, action);
         } else {
             return [];


### PR DESCRIPTION
- disable transactional edit predictions if the transaction is commited on the first update
  - this prevents some graphical bugs in e.g. splitting axis aligned segments
- for splitting axis-aligned segments, if the split edit is inconsistent with the edit for modifying the current segment, fall back to just splitting the segment
  - this allows splitting the segment when no with path being defined explicitly
  - this might cause unexpected results in very rare cases, however this is an acceptable tradeoff here